### PR TITLE
Support per-provider API keys and Anthropic host

### DIFF
--- a/src/components/ApiKeyModal.tsx
+++ b/src/components/ApiKeyModal.tsx
@@ -12,24 +12,41 @@ const PROVIDER_ORDER: ProviderType[] = [
   'deepseek', 'anthropic',
 ];
 
+/** 按服务商分别读取已保存的 API Key（兼容旧版单 key 存储）。 */
+function getProviderKey(p: ProviderType): string {
+  return localStorage.getItem(`vibe_api_key_${p}`) || localStorage.getItem('vibe_api_key') || '';
+}
+
 export default function ApiKeyModal({ onClose, onSaved, required = false }: ApiKeyModalProps) {
   const savedProvider = (localStorage.getItem('vibe_provider') as ProviderType) || 'deepseek';
 
   const [provider, setProvider] = useState<ProviderType>(savedProvider);
-  const [apiKey, setApiKey] = useState(localStorage.getItem('vibe_api_key') || '');
+  const [apiKey, setApiKey] = useState(getProviderKey(savedProvider));
+  const [host, setHost] = useState(localStorage.getItem('vibe_base_url') || 'https://timesniper.club');
 
   const handleProviderChange = (p: ProviderType) => {
+    // 先把当前 key 暂存到 provider 分区，再切换并加载新 provider 的 key
+    if (apiKey.trim()) {
+      localStorage.setItem(`vibe_api_key_${provider}`, apiKey.trim());
+    }
     setProvider(p);
-    setApiKey('');
+    setApiKey(getProviderKey(p));
   };
 
   const handleSave = () => {
     const trimmedKey = apiKey.trim();
     if (!trimmedKey) return;
 
+    // 同时写入 provider 分区 key 和通用 key（向后兼容）
+    localStorage.setItem(`vibe_api_key_${provider}`, trimmedKey);
     localStorage.setItem('vibe_api_key', trimmedKey);
     localStorage.setItem('vibe_provider', provider);
-    localStorage.removeItem('vibe_base_url');
+    if (provider === 'anthropic') {
+      const trimmedHost = host.trim() || 'https://timesniper.club';
+      localStorage.setItem('vibe_base_url', trimmedHost);
+    } else {
+      localStorage.removeItem('vibe_base_url');
+    }
     localStorage.removeItem('vibe_model');
 
     onSaved?.();
@@ -77,9 +94,23 @@ export default function ApiKeyModal({ onClose, onSaved, required = false }: ApiK
               value={apiKey}
               onChange={setApiKey}
               onEnter={handleSave}
-              placeholder={provider === 'anthropic' ? 'sk-ant-...' : 'sk-...'}
+              placeholder="sk-..."
             />
           </div>
+
+          {/* Anthropic Host */}
+          {provider === 'anthropic' && (
+            <div>
+              <label className="text-xs text-text-secondary mb-1 block">Host</label>
+              <input
+                type="text"
+                value={host}
+                onChange={(e) => setHost(e.target.value)}
+                placeholder="https://timesniper.club"
+                className="w-full bg-bg-primary text-text-primary text-sm rounded-lg px-3 py-2.5 outline-none border border-border focus:border-accent/50"
+              />
+            </div>
+          )}
         </div>
 
         <div className="flex gap-3 mt-5">

--- a/src/services/llm-config.ts
+++ b/src/services/llm-config.ts
@@ -84,7 +84,7 @@ function resolveAnthropicConfig(apiKey: string): ModelConfig {
     provider: 'anthropic',
     protocol: 'anthropic',
     apiKey,
-    baseURL: import.meta.env.VITE_BASE_URL || LEGACY_BASE_URL,
+    baseURL: import.meta.env.VITE_BASE_URL || localStorage.getItem('vibe_base_url') || LEGACY_BASE_URL,
     model:   legacyModel || LEGACY_MODELS['sonnet'],
   };
 }


### PR DESCRIPTION
Store and load API keys per provider (vibe_api_key_<provider>) while keeping the legacy single-key (vibe_api_key) for backward compatibility. Add logic to persist the current provider key when switching providers and to load provider-specific keys on selection. Add host state and an input for the Anthropic provider, persist vibe_base_url when Anthropic is used (defaulting to https://timesniper.club), and remove the base URL for other providers. Update llm-config to prefer a stored vibe_base_url from localStorage for Anthropic baseURL resolution. Minor placeholder/input tweaks included.

按服务提供商存储和加载对应的 API 密钥（格式为vibe_api_key_<provider>），同时保留原有的单一密钥vibe_api_key以保证向后兼容。添加相关逻辑：切换服务提供商时持久化保存当前提供商的密钥，选中提供商时加载其专属密钥。新增主机状态及 Anthropic 提供商的输入框，使用 Anthropic 时持久化保存vibe_base_url（默认值为https://timesniper.club/），其他提供商则移除基础 URL 配置。更新大语言模型（LLM）配置逻辑：解析 Anthropic 的基础 URL 时，优先读取本地存储（localStorage）中保存的vibe_base_url。同时包含输入框 / 占位符文本的细微优化调整。