### PR TITLE
Feature/fix background thread update code

### DIFF
--- a/docs/superpowers/plans/2026-04-29-session-status-indicators.md
+++ b/docs/superpowers/plans/2026-04-29-session-status-indicators.md
@@ -1,0 +1,230 @@
+# 会话状态指示器 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在历史面板的会话列表中，为每条条目显示"正在生成中"和"有未读结果"的视觉状态指示器。
+
+**Architecture:** 在 `App.tsx` 用内存 state `unreadSessions: Set<string>` 追踪未读会话，通过 `useEffect` 监听 `loadingSessions` 变化自动填入，切换会话时清除；将 `loadingSessions` 和 `unreadSessions` 透传给 `Sidebar` → `HistoryPanel`，在列表条目右侧渲染状态小圆点。
+
+**Tech Stack:** React, TypeScript, Tailwind CSS
+
+---
+
+## 文件变更清单
+
+| 文件 | 操作 | 说明 |
+|------|------|------|
+| `src/App.tsx` | 修改 | 新增 `unreadSessions` state、监听逻辑、清除逻辑；向 Sidebar 透传新 prop |
+| `src/components/Sidebar.tsx` | 修改 | 新增 `loadingSessions`、`unreadSessions` prop，透传给 HistoryPanel |
+| `src/components/HistoryPanel.tsx` | 修改 | 新增两个 prop，渲染状态指示器 |
+
+---
+
+### Task 1：App.tsx — 新增 unreadSessions state 与填入逻辑
+
+**Files:**
+- Modify: `src/App.tsx`
+
+- [ ] **Step 1：新增 state 与 prevLoadingRef**
+
+  在 `App.tsx` 中，找到现有的 state 声明区（`loadingSessions`、`isMoodLoading` 等），在其后添加：
+
+  ```tsx
+  const [unreadSessions, setUnreadSessions] = useState<Set<string>>(new Set());
+  const prevLoadingRef = useRef<Set<string>>(new Set());
+  ```
+
+- [ ] **Step 2：新增 useEffect 监听 loadingSessions 变化**
+
+  在 `currentIdRef` 的 `useEffect` 之后（约第 27 行附近），添加以下 effect：
+
+  ```tsx
+  useEffect(() => {
+    const prev = prevLoadingRef.current;
+    const curr = loadingSessions;
+    // 找出本轮从 loading 消失的 id（即生成完成的会话）
+    const completed = [...prev].filter((id) => !curr.has(id));
+    if (completed.length > 0) {
+      setUnreadSessions((prevUnread) => {
+        const next = new Set(prevUnread);
+        for (const id of completed) {
+          // 只有非当前会话才标为未读
+          if (id !== currentIdRef.current) {
+            next.add(id);
+          }
+        }
+        return next;
+      });
+    }
+    prevLoadingRef.current = curr;
+  }, [loadingSessions]);
+  ```
+
+- [ ] **Step 3：提交**
+
+  ```bash
+  git add src/App.tsx
+  git commit -m "feat: add unreadSessions state with auto-fill logic"
+  ```
+
+---
+
+### Task 2：App.tsx — 切换会话时清除未读标记，并透传 prop
+
+**Files:**
+- Modify: `src/App.tsx`
+
+- [ ] **Step 1：创建带清除逻辑的 handleSwitchSession**
+
+  在 `handleNewSession` 的 `useCallback` 之后，添加：
+
+  ```tsx
+  const handleSwitchSession = useCallback((id: string) => {
+    setUnreadSessions((prev) => {
+      if (!prev.has(id)) return prev;
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+    sessions.switchTo(id);
+  }, [sessions]);
+  ```
+
+- [ ] **Step 2：更新 Sidebar 的 prop 传递**
+
+  找到 `<Sidebar` 的 JSX，将现有的：
+
+  ```tsx
+  onSwitchSession={sessions.switchTo}
+  onDeleteSession={sessions.deleteSession}
+  ```
+
+  替换为：
+
+  ```tsx
+  loadingSessions={loadingSessions}
+  unreadSessions={unreadSessions}
+  onSwitchSession={handleSwitchSession}
+  onDeleteSession={sessions.deleteSession}
+  ```
+
+- [ ] **Step 3：提交**
+
+  ```bash
+  git add src/App.tsx
+  git commit -m "feat: clear unread on session switch, pass new props to Sidebar"
+  ```
+
+---
+
+### Task 3：Sidebar.tsx — 新增 prop 并透传
+
+**Files:**
+- Modify: `src/components/Sidebar.tsx`
+
+- [ ] **Step 1：更新 SidebarProps interface**
+
+  找到 `interface SidebarProps`，在 `isLoading: boolean;` 后添加：
+
+  ```tsx
+  loadingSessions?: Set<string>;
+  unreadSessions?: Set<string>;
+  ```
+
+- [ ] **Step 2：更新函数参数解构**
+
+  在解构参数中加入：
+
+  ```tsx
+  loadingSessions = new Set<string>(),
+  unreadSessions = new Set<string>(),
+  ```
+
+- [ ] **Step 3：透传给 HistoryPanel**
+
+  找到 `<HistoryPanel` 的 JSX，加入：
+
+  ```tsx
+  loadingSessions={loadingSessions}
+  unreadSessions={unreadSessions}
+  ```
+
+- [ ] **Step 4：提交**
+
+  ```bash
+  git add src/components/Sidebar.tsx
+  git commit -m "feat: pass loadingSessions and unreadSessions through Sidebar"
+  ```
+
+---
+
+### Task 4：HistoryPanel.tsx — 渲染状态指示器
+
+**Files:**
+- Modify: `src/components/HistoryPanel.tsx`
+
+- [ ] **Step 1：更新 HistoryPanelProps interface**
+
+  在 `interface HistoryPanelProps` 中加入：
+
+  ```tsx
+  loadingSessions?: Set<string>;
+  unreadSessions?: Set<string>;
+  ```
+
+- [ ] **Step 2：更新函数参数解构**
+
+  ```tsx
+  loadingSessions = new Set<string>(),
+  unreadSessions = new Set<string>(),
+  ```
+
+- [ ] **Step 3：在条目中渲染状态指示器**
+
+  找到条目内的 `<span className="flex-1 text-xs truncate"` 和删除按钮，将整个 `<div ... onClick={() => onSwitch(s.id)}>` 内部替换为：
+
+  ```tsx
+  <span className="flex-1 text-xs truncate" title={s.title}>
+    {s.title || '新会话'}
+  </span>
+  {/* 状态指示器 + 删除按钮 */}
+  <span className="flex items-center gap-1 shrink-0">
+    <button
+      onClick={(e) => {
+        e.stopPropagation();
+        onDelete(s.id);
+      }}
+      className="opacity-0 group-hover:opacity-100 text-text-muted hover:text-error text-base transition-opacity leading-none"
+      title="删除"
+    >
+      ×
+    </button>
+    {loadingSessions.has(s.id) ? (
+      <span className="w-1.5 h-1.5 rounded-full bg-accent animate-spin" style={{ animationDuration: '1s', border: '1.5px solid transparent', borderTopColor: 'currentColor' }} />
+    ) : unreadSessions.has(s.id) ? (
+      <span className="w-1.5 h-1.5 rounded-full bg-accent" />
+    ) : (
+      <span className="w-1.5 h-1.5" /> /* 占位，保持布局稳定 */
+    )}
+  </span>
+  ```
+
+  > **注意：** spinning dot 用 CSS border trick 实现旋转效果：设置透明 border 并让 `borderTopColor` 为 accent 色，配合 `animate-spin`。
+
+- [ ] **Step 4：验证视觉效果**
+
+  启动开发服务器：
+  ```bash
+  npm run dev
+  ```
+  打开历史面板，手动触发一个非当前会话的 AI 请求（或在代码中临时把某个 id 加入 unreadSessions），确认：
+  - 生成中：旋转小圆点出现
+  - 生成完成（非当前会话）：静态高亮小圆点出现
+  - 切换到该会话：小圆点消失
+
+- [ ] **Step 5：提交**
+
+  ```bash
+  git add src/components/HistoryPanel.tsx
+  git commit -m "feat: render session status indicators in HistoryPanel"
+  ```

--- a/docs/superpowers/specs/2026-04-29-session-status-indicators-design.md
+++ b/docs/superpowers/specs/2026-04-29-session-status-indicators-design.md
@@ -1,0 +1,79 @@
+# 设计规格：会话状态指示器
+
+**日期：** 2026-04-29  
+**状态：** 已批准
+
+## 背景
+
+用户在使用多会话时，切换到其他会话后，后台会话的 AI 生成进度和新结果无从感知。本功能在历史面板的会话列表中为每条会话加入视觉状态指示器。
+
+## 目标
+
+在历史面板会话列表中，每条条目能直观显示以下三种状态：
+
+1. **正在生成中** — AI 正在为该会话生成回复
+2. **有未读结果** — 该会话已生成完毕，但用户尚未访问
+3. **无特殊状态** — 正常状态
+
+## 状态定义
+
+| 状态 | 触发条件 | 清除条件 |
+|------|----------|----------|
+| 正在生成中 | 该会话 id 存在于 `loadingSessions` | 从 `loadingSessions` 移除时 |
+| 有未读结果 | 该会话从 loading 完成，且此时不是当前会话 | 用户切换到该会话 |
+
+## 架构
+
+### 状态管理（App.tsx）
+
+新增 `unreadSessions: Set<string>` state，纯内存，不持久化（刷新后视为已读）。
+
+**填入逻辑：**
+
+```
+useEffect 监听 loadingSessions：
+  对比上一轮（通过 useRef 保存），找出"本轮消失的 id"
+  若该 id !== currentId，则加入 unreadSessions
+```
+
+**清除逻辑：**
+
+```
+handleSwitchSession(id)：
+  切换会话时，从 unreadSessions 移除该 id
+```
+
+### 数据传递
+
+`App` → `Sidebar` → `HistoryPanel`，新增两个 prop：
+
+- `loadingSessions: Set<string>` — 正在生成中的会话 id 集合
+- `unreadSessions: Set<string>` — 有未读结果的会话 id 集合
+
+### 视觉渲染（HistoryPanel）
+
+每条条目右侧区域按优先级显示状态指示器：
+
+| 优先级 | 状态 | 视觉表现 |
+|--------|------|----------|
+| 1（最高） | 正在生成中 | 旋转动画小圆点（spinning dot，accent 色） |
+| 2 | 有未读结果 | 静态高亮小圆点（accent 色） |
+| 3 | 无特殊状态 | 无指示器 |
+
+生成中时只显示 spinning dot，不叠加未读点。
+
+**删除按钮**保持现有行为（hover 时出现），与指示器共存于同一右侧区域：指示器常显，删除按钮在 hover 时显示于其左侧。
+
+## 变更范围
+
+| 文件 | 变更内容 |
+|------|----------|
+| `src/App.tsx` | 新增 `unreadSessions` state、监听逻辑、清除逻辑；向 Sidebar 透传新 prop |
+| `src/components/Sidebar.tsx` | 新增 `loadingSessions`、`unreadSessions` prop，透传给 HistoryPanel |
+| `src/components/HistoryPanel.tsx` | 新增两个 prop，渲染状态指示器 |
+
+## 不在范围内
+
+- 持久化未读状态（刷新后重置合理）
+- 声音/通知等系统级提醒
+- 当前会话（currentId）的状态指示（已通过主界面 loading 状态体现）

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -313,6 +313,16 @@ export default function App() {
     if (isDemoMode()) setDemoStep(0);
   }, [strudel, sessions]);
 
+  const handleSwitchSession = useCallback((id: string) => {
+    setUnreadSessions((prev) => {
+      if (!prev.has(id)) return prev;
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+    sessions.switchTo(id);
+  }, [sessions]);
+
 
   return (
     <div className="flex h-screen w-screen bg-bg-primary overflow-hidden">
@@ -339,7 +349,9 @@ export default function App() {
         onNewSession={handleNewSession}
         onMoodGenerate={handleMoodInstruction}
         onReinitEngine={strudel.reinit}
-        onSwitchSession={sessions.switchTo}
+        loadingSessions={loadingSessions}
+        unreadSessions={unreadSessions}
+        onSwitchSession={handleSwitchSession}
         onDeleteSession={sessions.deleteSession}
         onOpenSettings={() => setShowApiKeyModal(true)}
         isHistoryLoading={sessions.isLoading}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,33 @@ export default function App() {
   const [loadingSessions, setLoadingSessions] = useState<Set<string>>(new Set());
   const [isMoodLoading, setIsMoodLoading] = useState(false);
   const [demoStep, setDemoStep] = useState(0);
+  const [unreadSessions, setUnreadSessions] = useState<Set<string>>(new Set());
   const abortControllersRef = useRef<Map<string, AbortController>>(new Map());
+  const currentIdRef = useRef<string | null>(sessions.currentId);
+  const prevLoadingRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    currentIdRef.current = sessions.currentId;
+  }, [sessions.currentId]);
+
+  useEffect(() => {
+    const prev = prevLoadingRef.current;
+    const curr = loadingSessions;
+    // 找出本轮从 loading 消失的 id（即生成完成的会话）
+    const completed = [...prev].filter((id) => !curr.has(id));
+    if (completed.length > 0) {
+      setUnreadSessions((prevUnread) => {
+        const next = new Set(prevUnread);
+        for (const id of completed) {
+          // 只有非当前会话才标为未读
+          if (id !== currentIdRef.current) {
+            next.add(id);
+          }
+        }
+        return next;
+      });
+    }
+    prevLoadingRef.current = curr;
+  }, [loadingSessions]);
 
   const isUserAbort = useCallback((error: unknown, signal?: AbortSignal) => {
     if (signal?.aborted) return true;
@@ -150,16 +176,22 @@ export default function App() {
           return;
         }
         if (result.code) {
-          const success = await strudel.play(result.code);
-          if (success) {
+          if (sessionId === currentIdRef.current) {
+            const success = await strudel.play(result.code);
+            if (success) {
+              sessions.addAssistantMessage(result.explanation, result.code, sessionId);
+              sessions.setCurrentCode(result.code, sessionId);
+            } else {
+              sessions.addAssistantMessage(
+                `agent 生成完了但代码无法运行: ${strudel.error || '未知错误'}`,
+                result.code,
+                sessionId
+              );
+            }
+          } else {
+            // 后台会话完成，仅保存结果，不更新编辑器也不播放音频
             sessions.addAssistantMessage(result.explanation, result.code, sessionId);
             sessions.setCurrentCode(result.code, sessionId);
-          } else {
-            sessions.addAssistantMessage(
-              `agent 生成完了但代码无法运行: ${strudel.error || '未知错误'}`,
-              result.code,
-              sessionId
-            );
           }
         } else {
           sessions.addAssistantMessage(result.explanation || 'agent 没有产出代码', undefined, sessionId);
@@ -241,16 +273,22 @@ export default function App() {
         return;
       }
       if (result.code) {
-        const success = await strudel.play(result.code);
-        if (success) {
+        if (sessionId === currentIdRef.current) {
+          const success = await strudel.play(result.code);
+          if (success) {
+            sessions.addAssistantMessage(result.explanation, result.code, sessionId);
+            sessions.setCurrentCode(result.code, sessionId);
+          } else {
+            sessions.addAssistantMessage(
+              `agent 生成完了但代码无法运行: ${strudel.error || '未知错误'}`,
+              result.code,
+              sessionId
+            );
+          }
+        } else {
+          // 后台会话完成，仅保存结果，不更新编辑器也不播放音频
           sessions.addAssistantMessage(result.explanation, result.code, sessionId);
           sessions.setCurrentCode(result.code, sessionId);
-        } else {
-          sessions.addAssistantMessage(
-            `agent 生成完了但代码无法运行: ${strudel.error || '未知错误'}`,
-            result.code,
-            sessionId
-          );
         }
       } else {
         sessions.addAssistantMessage(result.explanation || 'agent 没有产出代码', undefined, sessionId);

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -19,8 +19,10 @@ export default function HistoryPanel({
   loadingSessions = new Set<string>(),
   unreadSessions = new Set<string>(),
 }: HistoryPanelProps) {
-  // Newest first.
-  const ordered = [...sessions].sort((a, b) => b.updatedAt - a.updatedAt);
+  // Newest first (by start time). Exclude empty sessions (no messages).
+  const ordered = [...sessions]
+    .filter((s) => s.messages.length > 0)
+    .sort((a, b) => b.createdAt - a.createdAt);
 
   return (
     <div className="h-full flex flex-col bg-bg-primary border border-border overflow-hidden">

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -62,9 +62,9 @@ export default function HistoryPanel({
                         ×
                       </button>
                       {loadingSessions.has(s.id) ? (
-                        <span className="w-1.5 h-1.5 rounded-full animate-spin" style={{ border: '1.5px solid transparent', borderTopColor: 'var(--color-accent)', display: 'inline-block' }} />
+                        <span className="w-1.5 h-1.5 rounded-full animate-spin shrink-0" style={{ border: '1.5px solid transparent', borderTopColor: 'var(--color-text-primary)', display: 'inline-block' }} />
                       ) : unreadSessions.has(s.id) ? (
-                        <span className="w-1.5 h-1.5 rounded-full bg-accent" />
+                        <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ backgroundColor: 'var(--color-success)' }} />
                       ) : (
                         <span className="w-1.5 h-1.5 shrink-0" />
                       )}

--- a/src/components/HistoryPanel.tsx
+++ b/src/components/HistoryPanel.tsx
@@ -6,6 +6,8 @@ interface HistoryPanelProps {
   isLoading?: boolean;
   onSwitch: (id: string) => void;
   onDelete: (id: string) => void;
+  loadingSessions?: Set<string>;
+  unreadSessions?: Set<string>;
 }
 
 export default function HistoryPanel({
@@ -14,6 +16,8 @@ export default function HistoryPanel({
   isLoading = false,
   onSwitch,
   onDelete,
+  loadingSessions = new Set<string>(),
+  unreadSessions = new Set<string>(),
 }: HistoryPanelProps) {
   // Newest first.
   const ordered = [...sessions].sort((a, b) => b.updatedAt - a.updatedAt);
@@ -45,16 +49,26 @@ export default function HistoryPanel({
                     <span className="flex-1 text-xs truncate" title={s.title}>
                       {s.title || '新会话'}
                     </span>
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onDelete(s.id);
-                      }}
-                      className="opacity-0 group-hover:opacity-100 text-text-muted hover:text-error text-base transition-opacity shrink-0 leading-none"
-                      title="删除"
-                    >
-                      ×
-                    </button>
+                    {/* 状态指示器 + 删除按钮 */}
+                    <span className="flex items-center gap-1 shrink-0">
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onDelete(s.id);
+                        }}
+                        className="opacity-0 group-hover:opacity-100 text-text-muted hover:text-error text-base transition-opacity leading-none"
+                        title="删除"
+                      >
+                        ×
+                      </button>
+                      {loadingSessions.has(s.id) ? (
+                        <span className="w-1.5 h-1.5 rounded-full animate-spin" style={{ border: '1.5px solid transparent', borderTopColor: 'var(--color-accent)', display: 'inline-block' }} />
+                      ) : unreadSessions.has(s.id) ? (
+                        <span className="w-1.5 h-1.5 rounded-full bg-accent" />
+                      ) : (
+                        <span className="w-1.5 h-1.5 shrink-0" />
+                      )}
+                    </span>
                   </div>
                 </li>
               );

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -28,6 +28,8 @@ interface SidebarProps {
   onDeleteSession: (id: string) => void;
   onOpenSettings: () => void;
   isHistoryLoading?: boolean;
+  loadingSessions?: Set<string>;
+  unreadSessions?: Set<string>;
 }
 
 export default function Sidebar({
@@ -50,6 +52,8 @@ export default function Sidebar({
   onDeleteSession,
   onOpenSettings,
   isHistoryLoading = false,
+  loadingSessions = new Set<string>(),
+  unreadSessions = new Set<string>(),
 }: SidebarProps) {
   const [airjellyAvailable, setAirjellyAvailable] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
@@ -116,6 +120,8 @@ export default function Sidebar({
                 isLoading={isHistoryLoading}
                 onSwitch={(id) => { onSwitchSession(id); setShowHistory(false); }}
                 onDelete={onDeleteSession}
+                loadingSessions={loadingSessions}
+                unreadSessions={unreadSessions}
               />
             </div>
           </>

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -225,6 +225,14 @@ export function useSessions() {
         if (id && currentId !== id) setCurrentId(id);
         return prev;
       }
+      // If there's already an empty session in the list, switch to it instead
+      // of creating a duplicate. This handles the case where the user starts
+      // with a new session, switches to an old one, then clicks "New Session".
+      const existingEmpty = prev.find((s) => s.messages.length === 0 && !s.code);
+      if (existingEmpty) {
+        setCurrentId(existingEmpty.id);
+        return prev;
+      }
       const fresh = makeEmptySession();
       setCurrentId(fresh.id);
       dbPutSession(fresh);


### PR DESCRIPTION
This pull request implements session status indicators in the conversation history panel, allowing users to see at a glance which sessions are generating AI responses and which have unread results. The implementation involves state management in `App.tsx`, prop drilling through `Sidebar` to `HistoryPanel`, and UI rendering changes to show visual indicators for each session. The design and implementation are documented in newly added markdown files.

**Session Status Indicator Implementation:**

- **State Management & Business Logic**
  - Added `unreadSessions` state and logic in `App.tsx` to track sessions that have completed generation but have not yet been viewed. This uses a `useEffect` to compare previous and current `loadingSessions` and marks sessions as unread when they finish generating in the background. Unread status is cleared when the user switches to the session. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R22-R48) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R316-R325)
  - Updated code execution and result handling so that background sessions (not currently active) only save results and do not update the editor or play audio, ensuring the user is not interrupted. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R179) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R191-R195) [[3]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R276) [[4]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R288-R292)

- **Prop Drilling and Component Updates**
  - Updated `Sidebar` and `HistoryPanel` components to accept and forward the new `loadingSessions` and `unreadSessions` props, ensuring the status information flows from the app state to the UI. [[1]](diffhunk://#diff-5f3a5cc0c274c553bf7e5a260f594f138c16fd5197e1555cb608f862f0120f1cR31-R32) [[2]](diffhunk://#diff-5f3a5cc0c274c553bf7e5a260f594f138c16fd5197e1555cb608f862f0120f1cR55-R56) [[3]](diffhunk://#diff-5f3a5cc0c274c553bf7e5a260f594f138c16fd5197e1555cb608f862f0120f1cR123-R124) [[4]](diffhunk://#diff-1f75d67ab20cd1c84db890578c92dd7fa4c4d6e16b41179e0f2eb076fd40aa53R9-R10) [[5]](diffhunk://#diff-1f75d67ab20cd1c84db890578c92dd7fa4c4d6e16b41179e0f2eb076fd40aa53R19-R25)

- **UI Rendering**
  - Modified `HistoryPanel.tsx` to render status indicators for each session: a spinning dot for "generating", a static dot for "unread", and no indicator for normal sessions. The indicator appears to the right of each session title, alongside the delete button.

**Documentation and Design:**

- **Design Specification**
  - Added `docs/superpowers/specs/2026-04-29-session-status-indicators-design.md` detailing the rationale, goals, UI states, and technical approach for the session status indicators.
- **Implementation Plan**
  - Added `docs/superpowers/plans/2026-04-29-session-status-indicators.md` with a step-by-step breakdown of the implementation tasks, including architecture and file change checklist.

**Other Improvements:**

- Improved session switching logic to avoid duplicate empty sessions when creating new sessions.