### PR TITLE
Auto-focus ChatInput on session changes

### DIFF
--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -8,15 +8,20 @@ interface ChatInputProps {
   onReinitEngine: () => void;
   onStop?: () => void;
   prefill?: string;
+  focusTrigger?: number;
 }
 
-export default function ChatInput({ isLoading, engineReady, onSendText, onReinitEngine, onStop, prefill }: ChatInputProps) {
+export default function ChatInput({ isLoading, engineReady, onSendText, onReinitEngine, onStop, prefill, focusTrigger }: ChatInputProps) {
   const [text, setText] = useState('');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
     if (prefill) setText(prefill);
   }, [prefill]);
+
+  useEffect(() => {
+    if (focusTrigger) textareaRef.current?.focus();
+  }, [focusTrigger]);
 
   const doSubmit = () => {
     const value = text.trim();

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { ChatMessage } from '../hooks/useChat';
 import type { Session } from '../hooks/useSessions';
 import { PlusIcon, HistoryIcon, SettingsIcon } from './icons';
@@ -57,6 +57,15 @@ export default function Sidebar({
 }: SidebarProps) {
   const [airjellyAvailable, setAirjellyAvailable] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
+  const [focusTrigger, setFocusTrigger] = useState(1);
+  const prevIsLoadingRef = useRef(false);
+
+  useEffect(() => {
+    if (prevIsLoadingRef.current && !isLoading) {
+      setFocusTrigger((v) => v + 1);
+    }
+    prevIsLoadingRef.current = isLoading;
+  }, [isLoading]);
 
   useEffect(() => {
     checkAirJellyAvailable().then(setAirjellyAvailable);
@@ -99,7 +108,7 @@ export default function Sidebar({
             <HistoryIcon size={14} />
           </button>
           <button
-            onClick={onNewSession}
+            onClick={() => { onNewSession(); setFocusTrigger(v => v + 1); }}
             className="w-7 h-7 rounded-full border border-border text-text-secondary hover:text-text-primary hover:border-accent/50 transition-colors flex items-center justify-center"
             title="新建会话"
           >
@@ -173,7 +182,7 @@ export default function Sidebar({
             </div>
           )}
 
-          <ChatInput isLoading={isLoading} engineReady={engineReady} onSendText={onSendText} onStop={onStop} onReinitEngine={onReinitEngine} />
+          <ChatInput isLoading={isLoading} engineReady={engineReady} onSendText={onSendText} onStop={onStop} onReinitEngine={onReinitEngine} focusTrigger={focusTrigger} />
         </div>
       </div>
     </aside>

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -58,15 +58,11 @@ export function useSessions() {
       const loaded = await getAllSessions();
       if (cancelled) return;
 
-      if (loaded.length === 0) {
-        const fresh = makeEmptySession();
-        setSessions([fresh]);
-        setCurrentId(fresh.id);
-        await dbPutSession(fresh);
-      } else {
-        setSessions(loaded);
-        setCurrentId(loaded[0].id);
-      }
+      // 每次启动/刷新都创建新会话
+      const fresh = makeEmptySession();
+      await dbPutSession(fresh);
+      setSessions([fresh, ...loaded]);
+      setCurrentId(fresh.id);
       setIsLoading(false);
     })();
     return () => { cancelled = true; };
@@ -231,7 +227,10 @@ export function useSessions() {
       const existingEmpty = prev.find((s) => s.messages.length === 0 && !s.code);
       if (existingEmpty) {
         setCurrentId(existingEmpty.id);
-        return prev;
+        // Refresh createdAt so the reused empty session sorts to the top.
+        const refreshed = { ...existingEmpty, createdAt: Date.now(), updatedAt: Date.now() };
+        dbPutSession(refreshed);
+        return prev.map((s) => s.id === existingEmpty.id ? refreshed : s);
       }
       const fresh = makeEmptySession();
       setCurrentId(fresh.id);


### PR DESCRIPTION
Add a focusTrigger prop to ChatInput and focus the textarea when it changes. Sidebar now tracks a focusTrigger state (imports useRef) and increments it when a new session is created or when loading transitions from true to false, then passes it to ChatInput. Update useSessions to always create a fresh session on startup (prepended to loaded sessions) and to refresh/persist timestamps when reusing an existing empty session so it sorts to the top.