### PR TITLE
Prevent submit during IME composition

### DIFF
--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -48,7 +48,7 @@ export default function ChatInput({ isLoading, engineReady, onSendText, onReinit
         value={text}
         onChange={(e) => setText(e.target.value)}
         onKeyDown={(e) => {
-          if (e.key === 'Enter' && !e.shiftKey) {
+          if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
             e.preventDefault();
             handleSubmit(e);
           }


### PR DESCRIPTION
Check e.nativeEvent.isComposing in ChatInput onKeyDown to avoid submitting when Enter is pressed while an IME is composing (e.g., Japanese/Chinese). This prevents premature message sends during text composition by requiring composition to be finished before handling submit.