### PR TITLE
Show export duration and enhance ExportPopover

### DIFF
--- a/docs/superpowers/specs/2026-05-14-export-duration-display-design.md
+++ b/docs/superpowers/specs/2026-05-14-export-duration-display-design.md
@@ -1,0 +1,80 @@
+# 导出弹窗显示预计时长 — 设计规格
+
+**日期**：2026-05-14  
+**状态**：待实现
+
+---
+
+## 背景
+
+导出 WAV 时，用户输入起始/结束 cycle，但无法直接感知这段 cycle 对应的实际音频时长。需要根据当前 BPM 实时计算并展示。
+
+---
+
+## 目标
+
+在导出弹窗（`ExportPopover`）中，当用户修改 cycle 范围时，实时显示对应的预计音频时长。
+
+---
+
+## 时长计算
+
+```
+duration_seconds = (endCycle - beginCycle) × 240 / bpm
+```
+
+BPM 来源：`CodePanel` 的本地 state `bpm`，通过 prop 传入 `ExportPopover`。
+
+---
+
+## 时长格式化规则
+
+| 时长范围 | 显示格式 | 示例 |
+|---|---|---|
+| `< 60 秒` | `XX.X 秒` | `12.5 秒` |
+| `>= 60 秒` | `XX 分 XX 秒` | `1 分 30 秒` |
+
+- 秒数 `>= 60` 时，分钟取整除，秒取模后取整（`Math.floor`）。
+- 时长只在 `endCycle > beginCycle` 时显示（否则显示红色错误提示）。
+
+---
+
+## 数据流
+
+```
+CodePanel.bpm (state)
+  └─► <ExportPopover bpm={bpm} ...>
+        └─► duration = (endCycle - beginCycle) * 240 / bpm
+              └─► 格式化后渲染在 cycle 输入行与采样率行之间
+```
+
+---
+
+## UI 位置
+
+在"结束 cycle"输入行下方、"采样率"选择框上方，新增一行：
+
+```
+预计时长   XX.X 秒
+```
+
+样式与其他字段一致（`text-[12px] text-white/50`），标签用 `Field` 组件包裹，值部分只读文本。
+
+---
+
+## 改动范围
+
+### `src/components/ExportPopover.tsx`
+- `ExportPopoverProps` 新增 `bpm: number`
+- `ExportPopover` 解构接收 `bpm`
+- body 中 cycle 行与采样率行之间插入时长展示行（使用 `useMemo` 计算）
+
+### `src/components/CodePanel.tsx`
+- `<ExportPopover>` 调用处新增 `bpm={bpm}`
+
+---
+
+## 不在范围内
+
+- 在导出弹窗中修改 BPM
+- 将 BPM 状态提升到 `useStrudel` hook

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -424,6 +424,7 @@ export default function App() {
                 error={strudel.error}
                 isPlaying={strudel.isPlaying}
                 engineReady={strudel.engineReady}
+                hasCode={!!strudel.code}
                 onMount={strudel.setRoot}
                 onPlay={() => strudel.play()}
                 onStop={strudel.stop}
@@ -583,6 +584,7 @@ export default function App() {
             error={strudel.error}
             isPlaying={strudel.isPlaying}
             engineReady={strudel.engineReady}
+            hasCode={!!strudel.code}
             onMount={strudel.setRoot}
             onPlay={() => strudel.play()}
             onStop={strudel.stop}

--- a/src/components/CodePanel.tsx
+++ b/src/components/CodePanel.tsx
@@ -9,6 +9,7 @@ interface CodePanelProps {
   error: string | null;
   isPlaying: boolean;
   engineReady: boolean;
+  hasCode: boolean;
   onMount: (el: HTMLDivElement) => void;
   onPlay: () => void;
   onStop: () => void;
@@ -175,6 +176,7 @@ export default function CodePanel({
   error,
   isPlaying,
   engineReady,
+  hasCode,
   onMount,
   onPlay,
   onStop,
@@ -202,7 +204,10 @@ export default function CodePanel({
     await strudelService.setMasterVolume(volume);
     await strudelService.setMasterLPF(lpfSliderToHz(lpf));
     if (ok) {
-      setTimeout(() => setExportOpen(false), 800);
+      setTimeout(() => {
+        setExportOpen(false);
+        onResetExportState();
+      }, 800);
     }
     return ok;
   };
@@ -314,18 +319,21 @@ export default function CodePanel({
         />
         <button
           onClick={() => setExportOpen((v) => !v)}
-          disabled={!engineReady || exportState.status === 'exporting'}
-          title="导出 WAV"
-          className="absolute top-0.5 right-2 z-50 w-[28px] h-[28px] flex items-center justify-center text-white/60 hover:text-white/90 bg-black/40 backdrop-blur-sm rounded disabled:opacity-40 disabled:cursor-not-allowed"
+          disabled={!engineReady || !hasCode || exportState.status === 'exporting'}
+          title={!hasCode ? '请先输入代码' : '导出 WAV'}
+          className="absolute top-0.5 right-2 z-[51] w-[28px] h-[28px] flex items-center justify-center text-white/60 hover:text-white/90 bg-black/40 backdrop-blur-sm rounded disabled:opacity-40 disabled:cursor-not-allowed"
         >
           <DownloadIcon size={18} />
         </button>
         <ExportPopover
           open={exportOpen}
           onClose={() => setExportOpen(false)}
+          onToggle={() => setExportOpen((v) => !v)}
+          buttonDisabled={!engineReady || !hasCode || exportState.status === 'exporting'}
           onExport={handleExport}
           exportState={exportState}
           onResetState={onResetExportState}
+          bpm={bpm}
         />
       </div>
 

--- a/src/components/ExportPopover.tsx
+++ b/src/components/ExportPopover.tsx
@@ -4,6 +4,8 @@ import { useIsMobile } from '../hooks/useIsMobile';
 interface ExportPopoverProps {
   open: boolean;
   onClose: () => void;
+  onToggle?: () => void;
+  buttonDisabled?: boolean;
   onExport: (p: {
     filename: string;
     beginCycle: number;
@@ -16,12 +18,22 @@ interface ExportPopoverProps {
     error?: string;
   };
   onResetState: () => void;
+  bpm: number;
 }
 
-const SAMPLE_RATES = [44100, 48000] as const;
-
 function defaultFilename() {
-  return `oddenova-${new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)}`;
+  const now = new Date();
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const date = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}`;
+  const time = `${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+  return `oddeNova_${date}_${time}`;
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds.toFixed(1)} 秒`;
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m} 分 ${s} 秒`;
 }
 
 export default function ExportPopover({
@@ -30,34 +42,47 @@ export default function ExportPopover({
   onExport,
   exportState,
   onResetState,
+  bpm,
 }: ExportPopoverProps) {
   const isMobile = useIsMobile();
 
-  const [filename, setFilename] = useState(defaultFilename);
+  const [filename, setFilename] = useState('');
+  const [filenamePlaceholder] = useState(() => defaultFilename());
   const [beginCycle, setBeginCycle] = useState(0);
   const [endCycle, setEndCycle] = useState(4);
-  const [sampleRate, setSampleRate] = useState<number>(48000);
+  const [beginCycleStr, setBeginCycleStr] = useState('0');
+  const [endCycleStr, setEndCycleStr] = useState('4');
+  const [sampleRate, setSampleRate] = useState(48000);
 
-  // Refresh filename timestamp on each open->true transition (React "previous value" pattern).
-  const [prevOpen, setPrevOpen] = useState(open);
-  if (open !== prevOpen) {
-    setPrevOpen(open);
-    if (open && exportState.status === 'idle') {
-      setFilename(defaultFilename());
-    }
-  }
+  const commitBegin = (str: string) => {
+    const n = parseInt(str, 10);
+    const v = isNaN(n) ? 0 : Math.max(0, n);
+    setBeginCycle(v);
+    setBeginCycleStr(String(v));
+  };
+  const commitEnd = (str: string) => {
+    const n = parseInt(str, 10);
+    const v = isNaN(n) ? 0 : Math.max(0, n);
+    setEndCycle(v);
+    setEndCycleStr(String(v));
+  };
 
   const canExport = useMemo(
-    () => endCycle > beginCycle && filename.trim().length > 0,
-    [endCycle, beginCycle, filename],
+    () => endCycle > beginCycle,
+    [endCycle, beginCycle],
   );
+
+  const durationStr = useMemo(() => {
+    if (!canExport || bpm <= 0) return null;
+    return formatDuration((endCycle - beginCycle) * 240 / bpm);
+  }, [canExport, beginCycle, endCycle, bpm]);
 
   if (!open) return null;
 
   const handleExport = async () => {
     if (!canExport) return;
     await onExport({
-      filename: filename.trim(),
+      filename: filename.trim() || filenamePlaceholder,
       beginCycle,
       endCycle,
       sampleRate,
@@ -85,7 +110,7 @@ export default function ExportPopover({
           <div className="text-[13px] text-white/70">
             渲染中… {Math.round(exportState.progress * 100)}%
           </div>
-          <div className="h-[3px] w-full bg-[#323232] rounded overflow-hidden">
+          <div className="h-[3px] w-full bg-[#323232] overflow-hidden">
             <div
               className="h-full bg-white/70 transition-[width] duration-100 ease-linear"
               style={{ width: `${Math.round(exportState.progress * 100)}%` }}
@@ -94,7 +119,7 @@ export default function ExportPopover({
           <div className="flex justify-end">
             <button
               onClick={onClose}
-              className="px-3 py-1.5 text-[12px] text-white/70 hover:text-white/90 border border-[#323232] rounded"
+              className="px-3 py-1.5 text-[12px] text-white/70 hover:text-white/90 border border-[#323232]"
             >
               取消
             </button>
@@ -108,7 +133,7 @@ export default function ExportPopover({
           <div className="flex justify-end">
             <button
               onClick={handleErrorClose}
-              className="px-3 py-1.5 text-[12px] text-white/70 hover:text-white/90 border border-[#323232] rounded"
+              className="px-3 py-1.5 text-[12px] text-white/70 hover:text-white/90 border border-[#323232]"
             >
               关闭
             </button>
@@ -121,62 +146,65 @@ export default function ExportPopover({
               type="text"
               value={filename}
               onChange={(e) => setFilename(e.target.value)}
-              className="w-full bg-black border border-[#323232] rounded px-2 py-1.5 text-[12px] text-white/90 outline-none focus:border-white/30"
+              placeholder={filenamePlaceholder}
+              className="w-full bg-black border border-[#323232] px-2 py-1.5 text-[12px] text-white/90 outline-none focus:border-white/30 placeholder:text-white/30"
               style={{ fontFamily: "'ABeeZee', monospace" }}
             />
           </Field>
 
           <div className="flex gap-2">
             <Field label="起始 cycle">
-              <input
-                type="number"
-                min={0}
-                step={1}
-                value={beginCycle}
-                onChange={(e) => setBeginCycle(Number(e.target.value) || 0)}
-                className="w-full bg-black border border-[#323232] rounded px-2 py-1.5 text-[12px] text-white/90 outline-none focus:border-white/30"
-                style={{ fontFamily: "'ABeeZee', monospace" }}
+              <CycleInput
+                value={beginCycleStr}
+                onChange={setBeginCycleStr}
+                onCommit={commitBegin}
               />
             </Field>
             <Field label="结束 cycle">
-              <input
-                type="number"
-                min={0}
-                step={1}
-                value={endCycle}
-                onChange={(e) => setEndCycle(Number(e.target.value) || 0)}
-                className="w-full bg-black border border-[#323232] rounded px-2 py-1.5 text-[12px] text-white/90 outline-none focus:border-white/30"
-                style={{ fontFamily: "'ABeeZee', monospace" }}
+              <CycleInput
+                value={endCycleStr}
+                onChange={setEndCycleStr}
+                onCommit={commitEnd}
               />
             </Field>
           </div>
+
+          {durationStr && (
+            <div className="flex items-center justify-between text-[12px]">
+              <span className="text-white/50">预计时长</span>
+              <span className="text-white/80" style={{ fontFamily: "'ABeeZee', monospace" }}>{durationStr}</span>
+            </div>
+          )}
+
+          {!canExport && (
+            <div className="text-[12px] text-red-400">
+              起始 cycle 必须小于结束 cycle
+            </div>
+          )}
 
           <Field label="采样率">
             <select
               value={sampleRate}
               onChange={(e) => setSampleRate(Number(e.target.value))}
-              className="w-full bg-black border border-[#323232] rounded px-2 py-1.5 text-[12px] text-white/90 outline-none focus:border-white/30"
+              className="w-full bg-black border border-[#323232] px-2 py-1.5 text-[12px] text-white/90 outline-none focus:border-white/30"
               style={{ fontFamily: "'ABeeZee', monospace" }}
             >
-              {SAMPLE_RATES.map((sr) => (
-                <option key={sr} value={sr}>
-                  {sr} Hz
-                </option>
-              ))}
+              <option value={44100}>44100 Hz</option>
+              <option value={48000}>48000 Hz</option>
             </select>
           </Field>
 
           <div className="flex justify-end gap-2 pt-1">
             <button
               onClick={onClose}
-              className="px-3 py-1.5 text-[12px] text-white/70 hover:text-white/90 border border-[#323232] rounded"
+              className="px-3 py-1.5 text-[12px] text-white/70 hover:text-white/90 border border-[#323232]"
             >
               取消
             </button>
             <button
               onClick={handleExport}
               disabled={!canExport}
-              className="px-3 py-1.5 text-[12px] text-white border border-white/30 rounded hover:bg-white/10 disabled:opacity-40 disabled:cursor-not-allowed"
+              className="px-3 py-1.5 text-[12px] text-white border border-white/30 hover:bg-white/10 disabled:opacity-40 disabled:cursor-not-allowed"
             >
               导出
             </button>
@@ -207,17 +235,78 @@ export default function ExportPopover({
   }
 
   return (
-    <div
-      className="absolute -top-px -right-px z-40 w-[280px] bg-[#111] border border-[#323232] shadow-xl p-3"
-      onClick={(e) => e.stopPropagation()}
-    >
+    <>
+      <div className="fixed inset-0 z-40" onClick={handleCloseSafe} />
       <div
-        className="text-[12px] text-white/90 font-bold mb-6"
-        style={{ fontFamily: "'ABeeZee', monospace" }}
+        className="absolute top-0 right-0 z-50 w-[280px] bg-[#111] border border-[#323232] shadow-xl p-3"
+        onClick={(e) => e.stopPropagation()}
       >
-        导出 WAV
+        <div className="text-[12px] text-white/90 font-bold mb-6"
+          style={{ fontFamily: "'ABeeZee', monospace" }}
+        >
+          导出 WAV
+        </div>
+        {body}
       </div>
-      {body}
+    </>
+  );
+}
+
+function CycleInput({
+  value,
+  onChange,
+  onCommit,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  onCommit: (v: string) => void;
+}) {
+  const step = (delta: number) => {
+    const n = parseInt(value, 10);
+    const next = String(isNaN(n) ? Math.max(0, delta) : Math.max(0, n + delta));
+    onChange(next);
+    onCommit(next);
+  };
+
+  return (
+    <div className="flex w-full border border-[#323232] overflow-hidden focus-within:border-white/30 bg-black">
+      <input
+        type="text"
+        inputMode="numeric"
+        value={value}
+        onChange={(e) => onChange(e.target.value.replace(/[^0-9-]/g, ''))}
+        onBlur={(e) => onCommit(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') onCommit(value);
+          if (e.key === 'ArrowUp') { e.preventDefault(); step(1); }
+          if (e.key === 'ArrowDown') { e.preventDefault(); step(-1); }
+        }}
+        className="flex-1 min-w-0 bg-transparent px-2 py-1.5 text-[12px] text-white/90 outline-none"
+        style={{ fontFamily: "'ABeeZee', monospace" }}
+      />
+      <div className="flex flex-col border-l border-[#323232]">
+        <button
+          type="button"
+          onClick={() => step(1)}
+          className="flex-1 flex items-center justify-center px-1.5 text-white/50 hover:text-white/90 hover:bg-white/5 leading-none"
+          tabIndex={-1}
+        >
+          <svg width="8" height="5" viewBox="0 0 8 5" fill="none">
+            <path d="M4 0.5L7.5 4.5H0.5L4 0.5Z" fill="currentColor" />
+          </svg>
+        </button>
+        <div className="h-px bg-[#323232]" />
+        <button
+          type="button"
+          onClick={() => step(-1)}
+          className="flex-1 flex items-center justify-center px-1.5 text-white/50 hover:text-white/90 hover:bg-white/5 leading-none"
+          tabIndex={-1}
+        >
+          <svg width="8" height="5" viewBox="0 0 8 5" fill="none">
+            <path d="M4 4.5L0.5 0.5H7.5L4 4.5Z" fill="currentColor" />
+          </svg>
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/hooks/useStrudel.ts
+++ b/src/hooks/useStrudel.ts
@@ -92,7 +92,7 @@ export function useStrudel() {
           ...params,
           onProgress: (p) => setExportState((s) => ({ ...s, progress: p })),
         });
-        setExportState({ status: 'idle', progress: 1 });
+        setExportState((s) => ({ ...s, progress: 1 }));
         return true;
       } catch (e) {
         const message = e instanceof Error ? e.message : String(e);


### PR DESCRIPTION
Add design spec and UI/logic to display estimated export duration and improve the export popover.

- docs: add spec docs/superpowers/specs/2026-05-14-export-duration-display-design.md describing duration calc and UI.
- ExportPopover: accept bpm, compute & format estimated duration ((end-begin)*240/bpm) and render it; add CycleInput component for robust cycle editing (text input + step buttons); use filename placeholder with new timestamp format; minor class/style and select refactors; expose onToggle and buttonDisabled props.
- CodePanel: pass bpm and onToggle/buttonDisabled to ExportPopover; disable export button when no code (hasCode) and reset export state after successful export close.
- App: pass hasCode to CodePanel instances.
- useStrudel: fix export state update to preserve status while setting progress to 1.

These changes let the export dialog show a live, BPM-based duration estimate and improve cycle input UX and filename handling.