### PR TITLE
Render mood-generation button only when available

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -167,12 +167,12 @@ export default function Sidebar({
                   来首曲子
                 </button>
               )}
-              {!navigator.userAgent.includes('Windows') && (
+              {!navigator.userAgent.includes('Windows') && (airjellyAvailable || isDemoMode()) && (
                 <button
                   type="button"
                   onClick={onMoodGenerate}
-                  disabled={(!airjellyAvailable && !isDemoMode()) || isMoodLoading}
-                  title={airjellyAvailable || isDemoMode() ? '根据你最近的活动感知心情生成音乐' : '需要运行 AirJelly Desktop'}
+                  disabled={isMoodLoading}
+                  title="根据你最近的活动感知心情生成音乐"
                   className="rounded-[8px] bg-transparent border border-border px-3 py-1.5 text-[11px] text-[#e0e0e0] transition hover:border-accent/50 hover:text-text-primary disabled:opacity-40 disabled:cursor-not-allowed"
                   style={{ fontFamily: '"GenWanMin TW", serif' }}
                 >


### PR DESCRIPTION
Sidebar: only render the mood-generation button on non-Windows when AirJelly is available or in demo mode (airjellyAvailable || isDemoMode()). Simplify disabled logic to depend solely on isMoodLoading and make the tooltip text constant ("根据你最近的活动感知心情生成音乐"). This hides an inoperable control and clarifies UX by removing the alternate "need to run AirJelly Desktop" state.