### PR TITLE
Release preview

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -323,6 +323,13 @@ export default function App() {
     [sessions, handleInstruction, strudel]
   );
 
+  const handleBranch = useCallback(
+    (messageId: string) => {
+      sessions.branchFromMessage(messageId);
+    },
+    [sessions]
+  );
+
   const handleMoodInstruction = useCallback(async () => {
     if (!strudel.engineReady) {
       strudel.setError('音频引擎启动中，请稍后再试');
@@ -507,7 +514,7 @@ export default function App() {
 
         {/* ── Conversation ── */}
         <div className="flex-1 min-h-0 overflow-hidden">
-          <ConversationView key={sessions.currentId ?? 'default'} messages={messages} isLoading={isLoading} onResend={handleResend} />
+          <ConversationView key={sessions.currentId ?? 'default'} messages={messages} isLoading={isLoading} onResend={handleResend} onBranch={handleBranch} />
         </div>
 
         {/* ── Code Drawer ── */}
@@ -682,6 +689,7 @@ export default function App() {
           isReplaying={isReplaying}
           replayInputText={replayInputText}
           onResend={handleResend}
+          onBranch={handleBranch}
         />
       </div>
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -179,8 +179,9 @@ export default function App() {
         setDemoStep((s) => s + 1);
       }
 
-      abortControllersRef.current.set(sessionId, new AbortController());
-      const signal = abortControllersRef.current.get(sessionId)!.signal;
+      const controller = new AbortController();
+      abortControllersRef.current.set(sessionId, controller);
+      const signal = controller.signal;
       const _analyticsStart = Date.now();
       const { provider: _analyticsProvider, model: _analyticsModel } = getActiveModelConfig();
 
@@ -241,7 +242,9 @@ export default function App() {
 
         const result = await runAgent(text, options?.initialCode ?? currentCode, onProgress, undefined, signal);
         if (signal.aborted) {
-          sessions.addAssistantMessage('已中断', undefined, sessionId);
+          if (abortControllersRef.current.get(sessionId) === controller) {
+            sessions.addAssistantMessage('已中断', undefined, sessionId);
+          }
           trackAgentAbort();
           return;
         }
@@ -277,7 +280,9 @@ export default function App() {
         }
       } catch (e: unknown) {
         if (isUserAbort(e, signal)) {
-          sessions.addAssistantMessage('已中断', undefined, sessionId);
+          if (abortControllersRef.current.get(sessionId) === controller) {
+            sessions.addAssistantMessage('已中断', undefined, sessionId);
+          }
           trackAgentAbort();
         } else {
           const errMsg = e instanceof Error ? e.message : '请求失败';
@@ -290,8 +295,10 @@ export default function App() {
           });
         }
       } finally {
-        abortControllersRef.current.delete(sessionId);
-        setLoadingSessions((prev) => { const next = new Set(prev); next.delete(sessionId); return next; });
+        if (abortControllersRef.current.get(sessionId) === controller) {
+          abortControllersRef.current.delete(sessionId);
+          setLoadingSessions((prev) => { const next = new Set(prev); next.delete(sessionId); return next; });
+        }
       }
     },
     [strudel, sessions, currentCode, demoStep, activeSet, isUserAbort]
@@ -299,6 +306,11 @@ export default function App() {
 
   const handleResend = useCallback(
     async (messageId: string, newContent: string) => {
+      // Abort any in-progress run before resending
+      const currentSessionId = sessions.currentId;
+      if (currentSessionId) {
+        abortControllersRef.current.get(currentSessionId)?.abort();
+      }
       // 找到该消息之前最后一条有代码的 assistant 消息，作为回退目标
       const allMessages = sessions.currentSession?.messages ?? [];
       const idx = allMessages.findIndex((m) => m.id === messageId);
@@ -323,11 +335,16 @@ export default function App() {
     [sessions, handleInstruction, strudel]
   );
 
-  const handleBranch = useCallback(
-    (messageId: string) => {
-      sessions.branchFromMessage(messageId);
+  const handleRetry = useCallback(
+    async (assistantMessageId: string) => {
+      const allMessages = sessions.currentSession?.messages ?? [];
+      const idx = allMessages.findIndex((m) => m.id === assistantMessageId);
+      if (idx < 0) return;
+      const userMsg = [...allMessages.slice(0, idx)].reverse().find((m) => m.role === 'user');
+      if (!userMsg) return;
+      await handleResend(userMsg.id, userMsg.content);
     },
-    [sessions]
+    [sessions, handleResend]
   );
 
   const handleMoodInstruction = useCallback(async () => {
@@ -514,7 +531,7 @@ export default function App() {
 
         {/* ── Conversation ── */}
         <div className="flex-1 min-h-0 overflow-hidden">
-          <ConversationView key={sessions.currentId ?? 'default'} messages={messages} isLoading={isLoading} onResend={handleResend} onBranch={handleBranch} />
+          <ConversationView key={sessions.currentId ?? 'default'} messages={messages} isLoading={isLoading} onResend={handleResend} onBranch={sessions.branchFromMessage} onRetry={handleRetry} />
         </div>
 
         {/* ── Code Drawer ── */}
@@ -689,7 +706,8 @@ export default function App() {
           isReplaying={isReplaying}
           replayInputText={replayInputText}
           onResend={handleResend}
-          onBranch={handleBranch}
+          onBranch={sessions.branchFromMessage}
+          onRetry={handleRetry}
         />
       </div>
 

--- a/src/components/ConversationView.tsx
+++ b/src/components/ConversationView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import type { ChatMessage } from '../hooks/useChat';
-import { ArrowUpIcon, CheckIcon, CopyIcon, EditIcon, XIcon } from './icons';
+import { ArrowUpIcon, CheckIcon, CopyIcon, EditIcon, GitBranchIcon, XIcon } from './icons';
 
 function stripMarkdown(text: string): string {
   return text
@@ -22,12 +22,14 @@ interface ConversationViewProps {
   messages: ChatMessage[];
   isLoading: boolean;
   onResend: (messageId: string, content: string) => void;
+  onBranch: (messageId: string) => void;
 }
 
 export default function ConversationView({
   messages,
   isLoading,
   onResend,
+  onBranch,
 }: ConversationViewProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const editTextareaRef = useRef<HTMLTextAreaElement>(null);
@@ -183,9 +185,9 @@ export default function ConversationView({
         return (
           <div
             key={msg.id}
-            className="flex justify-start animate-fade-in-up"
+            className="flex justify-start animate-fade-in-up group"
           >
-            <div className="max-w-[85%] rounded-xl px-3 py-2 text-xs bg-transparent text-text-primary">
+            <div className="relative max-w-[85%] rounded-xl px-3 py-2 text-xs bg-transparent text-text-primary">
               <p className="whitespace-pre-wrap break-words">{msg.content}</p>
               {msg.code && (() => {
                 const isExpanded = expandedCode.has(msg.id);
@@ -208,6 +210,16 @@ export default function ConversationView({
                   </div>
                 );
               })()}
+              {/* Branch button — bottom-left, visible on group-hover */}
+              <div className="absolute -bottom-5 left-0 flex items-center opacity-0 group-hover:opacity-100 transition-opacity">
+                <button
+                  onClick={() => onBranch(msg.id)}
+                  className="text-white/60 hover:text-white p-1"
+                  title="从此处创建分支对话"
+                >
+                  <GitBranchIcon size={13} />
+                </button>
+              </div>
             </div>
           </div>
         );

--- a/src/components/ConversationView.tsx
+++ b/src/components/ConversationView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import type { ChatMessage } from '../hooks/useChat';
-import { ArrowUpIcon, CheckIcon, CopyIcon, EditIcon, GitBranchIcon, XIcon } from './icons';
+import { ArrowUpIcon, CheckIcon, CopyIcon, EditIcon, GitBranchIcon, RetryIcon, XIcon } from './icons';
 
 function stripMarkdown(text: string): string {
   return text
@@ -23,6 +23,7 @@ interface ConversationViewProps {
   isLoading: boolean;
   onResend: (messageId: string, content: string) => void;
   onBranch: (messageId: string) => void;
+  onRetry: (messageId: string) => void;
 }
 
 export default function ConversationView({
@@ -30,6 +31,7 @@ export default function ConversationView({
   isLoading,
   onResend,
   onBranch,
+  onRetry,
 }: ConversationViewProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const editTextareaRef = useRef<HTMLTextAreaElement>(null);
@@ -167,9 +169,8 @@ export default function ConversationView({
                       {copiedId === msg.id ? <CheckIcon size={13} /> : <CopyIcon size={13} />}
                     </button>
                     <button
-                      disabled={isLoading}
                       onClick={() => { setEditingId(msg.id); setEditText(msg.content); }}
-                      className="text-white/60 hover:text-white disabled:opacity-0 disabled:cursor-not-allowed p-1"
+                      className="text-white/60 hover:text-white p-1"
                       title="编辑"
                     >
                       <EditIcon size={13} />
@@ -185,7 +186,7 @@ export default function ConversationView({
         return (
           <div
             key={msg.id}
-            className="flex justify-start animate-fade-in-up group"
+            className="flex justify-start animate-fade-in-up group mb-6"
           >
             <div className="relative max-w-[85%] rounded-xl px-3 py-2 text-xs bg-transparent text-text-primary">
               <p className="whitespace-pre-wrap break-words">{msg.content}</p>
@@ -210,8 +211,15 @@ export default function ConversationView({
                   </div>
                 );
               })()}
-              {/* Branch button — bottom-left, visible on group-hover */}
-              <div className="absolute -bottom-5 left-0 flex items-center opacity-0 group-hover:opacity-100 transition-opacity">
+              {/* Action buttons — bottom-left, always visible */}
+              <div className="absolute -bottom-5 left-0 flex items-center">
+                <button
+                  onClick={() => onRetry(msg.id)}
+                  className="text-white/60 hover:text-white p-1"
+                  title="重试"
+                >
+                  <RetryIcon size={13} />
+                </button>
                 <button
                   onClick={() => onBranch(msg.id)}
                   className="text-white/60 hover:text-white p-1"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -34,6 +34,7 @@ interface SidebarProps {
   isReplaying?: boolean;
   replayInputText?: string;
   onResend: (messageId: string, content: string) => void;
+  onBranch: (messageId: string) => void;
 }
 
 export default function Sidebar({
@@ -61,6 +62,7 @@ export default function Sidebar({
   isReplaying = false,
   replayInputText,
   onResend,
+  onBranch,
 }: SidebarProps) {
   const [airjellyAvailable, setAirjellyAvailable] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
@@ -149,6 +151,7 @@ export default function Sidebar({
           messages={messages}
           isLoading={isLoading && !isReplaying}
           onResend={onResend}
+          onBranch={onBranch}
         />
       </div>
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -35,6 +35,7 @@ interface SidebarProps {
   replayInputText?: string;
   onResend: (messageId: string, content: string) => void;
   onBranch: (messageId: string) => void;
+  onRetry: (messageId: string) => void;
 }
 
 export default function Sidebar({
@@ -63,6 +64,7 @@ export default function Sidebar({
   replayInputText,
   onResend,
   onBranch,
+  onRetry,
 }: SidebarProps) {
   const [airjellyAvailable, setAirjellyAvailable] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
@@ -152,6 +154,7 @@ export default function Sidebar({
           isLoading={isLoading && !isReplaying}
           onResend={onResend}
           onBranch={onBranch}
+          onRetry={onRetry}
         />
       </div>
 

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -155,3 +155,14 @@ export function XIcon({ size = 16, className }: IconProps) {
     </svg>
   );
 }
+
+export function GitBranchIcon({ size = 16, className }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className={className}>
+      <line x1="6" y1="3" x2="6" y2="15" />
+      <circle cx="18" cy="6" r="3" />
+      <circle cx="6" cy="18" r="3" />
+      <path d="M18 9a9 9 0 0 1-9 9" />
+    </svg>
+  );
+}

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -156,13 +156,40 @@ export function XIcon({ size = 16, className }: IconProps) {
   );
 }
 
+export function RetryIcon({ size = 16, className }: IconProps) {
+  // Center (12,12) R=7. CW tangent at θ: (-sinθ, cosθ).
+  // Arc 1: θ=220°→340° (120° CW through 12 o'clock)
+  //   start=(6.64,7.50) end=(18.58,9.61) t=(0.342,0.940) n=(-0.940,0.342)
+  //   wings: tip-2.5t±1.5n → (16.31,7.77) (19.13,6.74)
+  // Arc 2: θ=40°→160° (120° CW through 6 o'clock) — 180° symmetric
+  //   start=(17.36,16.50) end=(5.42,14.39) wings=(7.69,16.23) (4.87,17.26)
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" className={className}>
+      <path d="M 6.64 7.50 A 7 7 0 0 1 18.58 9.61"
+            stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      <polyline points="16.31,7.77 18.58,9.61 19.13,6.74"
+                fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M 17.36 16.50 A 7 7 0 0 1 5.42 14.39"
+            stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      <polyline points="7.69,16.23 5.42,14.39 4.87,17.26"
+                fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  );
+}
+
 export function GitBranchIcon({ size = 16, className }: IconProps) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className={className}>
-      <line x1="6" y1="3" x2="6" y2="15" />
-      <circle cx="18" cy="6" r="3" />
-      <circle cx="6" cy="18" r="3" />
-      <path d="M18 9a9 9 0 0 1-9 9" />
+      {/* horizontal stem */}
+      <line x1="3" y1="12" x2="10" y2="12" />
+      {/* upper branch → NE */}
+      <line x1="10" y1="12" x2="20" y2="4" />
+      {/* upper arrowhead: L-bracket at top-right */}
+      <polyline points="14,4 20,4 20,10" />
+      {/* lower branch → SE */}
+      <line x1="10" y1="12" x2="20" y2="20" />
+      {/* lower arrowhead: L-bracket at bottom-right */}
+      <polyline points="14,20 20,20 20,14" />
     </svg>
   );
 }

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -303,10 +303,10 @@ export function useSessions() {
   );
 
   const branchFromMessage = useCallback(
-    async (messageId: string): Promise<void> => {
+    (targetMessageId: string): void => {
       const session = sessions.find((s) => s.id === currentId) || sessions[0];
       if (!session) return;
-      const index = session.messages.findIndex((m) => m.id === messageId);
+      const index = session.messages.findIndex((m) => m.id === targetMessageId);
       if (index === -1) return;
       const sliced = session.messages.slice(0, index + 1);
       // Use the code from the target assistant message if available
@@ -322,6 +322,9 @@ export function useSessions() {
         createdAt: now,
         updatedAt: now,
       };
+      // Optimistic update: UI reflects immediately; DB write is fire-and-forget.
+      // If dbPutSession fails, the session exists in memory for the current page
+      // load but won't persist on refresh.
       setSessions((prev) => [branched, ...prev]);
       setCurrentId(id);
       dbPutSession(branched).catch(console.error);

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -322,9 +322,9 @@ export function useSessions() {
         createdAt: now,
         updatedAt: now,
       };
-      await dbPutSession(branched);
       setSessions((prev) => [branched, ...prev]);
       setCurrentId(id);
+      dbPutSession(branched).catch(console.error);
     },
     [sessions, currentId]
   );

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -302,6 +302,33 @@ export function useSessions() {
     []
   );
 
+  const branchFromMessage = useCallback(
+    async (messageId: string): Promise<void> => {
+      const session = sessions.find((s) => s.id === currentId) || sessions[0];
+      if (!session) return;
+      const index = session.messages.findIndex((m) => m.id === messageId);
+      if (index === -1) return;
+      const sliced = session.messages.slice(0, index + 1);
+      // Use the code from the target assistant message if available
+      const targetMsg = session.messages[index];
+      const code = (targetMsg.role === 'assistant' && targetMsg.code) ? targetMsg.code : session.code;
+      const id = newSessionId();
+      const now = Date.now();
+      const branched: Session = {
+        id,
+        title: `${session.title}（分支）`,
+        messages: sliced,
+        code,
+        createdAt: now,
+        updatedAt: now,
+      };
+      await dbPutSession(branched);
+      setSessions((prev) => [branched, ...prev]);
+      setCurrentId(id);
+    },
+    [sessions, currentId]
+  );
+
   return {
     sessions,
     currentSession,
@@ -317,5 +344,6 @@ export function useSessions() {
     switchTo,
     deleteSession,
     importSession,
+    branchFromMessage,
   };
 }


### PR DESCRIPTION
This pull request introduces two major user experience improvements to the chat application: (1) users can now easily retry an assistant response or branch a new conversation from any previous message, and (2) the handling of aborting/resending agent runs is made more robust. Several UI enhancements and new icons support these features.

**New conversation actions:**

* Added "Retry" and "Branch" buttons to each assistant message in `ConversationView`, allowing users to retry the assistant's response or start a new branch conversation from any message. The UI for these actions is always visible below each message. [[1]](diffhunk://#diff-6ce750d9e596521f4d7ed3bc8d2e51cf57c55459881fa5515dc1e66d61373258R214-R230) [[2]](diffhunk://#diff-6ce750d9e596521f4d7ed3bc8d2e51cf57c55459881fa5515dc1e66d61373258R25-R34) [[3]](diffhunk://#diff-5f3a5cc0c274c553bf7e5a260f594f138c16fd5197e1555cb608f862f0120f1cR37-R38) [[4]](diffhunk://#diff-5f3a5cc0c274c553bf7e5a260f594f138c16fd5197e1555cb608f862f0120f1cR66-R67) [[5]](diffhunk://#diff-5f3a5cc0c274c553bf7e5a260f594f138c16fd5197e1555cb608f862f0120f1cR156-R157) [[6]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R338-R349) [[7]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L510-R534) [[8]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R709-R710)
* Implemented the `branchFromMessage` function in `useSessions.ts`, which creates a new session up to the selected message, optionally using the code from that assistant message. The new session appears immediately in the UI. [[1]](diffhunk://#diff-e23c1d87f4c34dad73df93bb3595473dc69a7e2c79b5faa75a68fa83f3ad4741R305-R334) [[2]](diffhunk://#diff-e23c1d87f4c34dad73df93bb3595473dc69a7e2c79b5faa75a68fa83f3ad4741R350)

**Agent run and abort handling:**

* Improved abort logic to ensure that only the relevant abort controller for the current session triggers UI updates and cleanup, preventing race conditions when multiple sessions are running or retried. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L182-R184) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R245-R247) [[3]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R283-R285) [[4]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R298-R313)
* When resending a user message, the app now aborts any in-progress run for the current session before starting the resend, ensuring consistent state.

**UI and icon updates:**

* Added new `RetryIcon` and `GitBranchIcon` SVG components for the new actions, and updated icon imports throughout the UI. [[1]](diffhunk://#diff-1a97f6b4c616038c740261e7c3091969a7517bf19c3c4778edb72320e7bcf17aR158-R195) [[2]](diffhunk://#diff-6ce750d9e596521f4d7ed3bc8d2e51cf57c55459881fa5515dc1e66d61373258L3-R3)
* Minor UI tweaks: action buttons are always visible below each assistant message, and the edit button is now always enabled (not disabled during loading). [[1]](diffhunk://#diff-6ce750d9e596521f4d7ed3bc8d2e51cf57c55459881fa5515dc1e66d61373258L168-R173) [[2]](diffhunk://#diff-6ce750d9e596521f4d7ed3bc8d2e51cf57c55459881fa5515dc1e66d61373258L186-R191)

These changes make it much easier for users to experiment with alternate conversation paths and recover from failed assistant responses.