### PR TITLE
Add global Alt+. play/stop shortcut

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -159,6 +159,24 @@ export default function App() {
   // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: only re-run when session ID changes
   }, [current?.id]);
 
+  // Option+. (Alt+.) global play/stop toggle — matches strudel's Alt+. keybinding
+  const strudelRef = useRef(strudel);
+  strudelRef.current = strudel;
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.altKey && e.code === 'Period' && e.key !== '.') {
+        e.preventDefault();
+        if (strudelRef.current.isPlaying) {
+          strudelRef.current.stop();
+        } else if (strudelRef.current.engineReady) {
+          void strudelRef.current.play();
+        }
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
   const handleInstruction = useCallback(
     async (text: string, options?: { skipAddMessage?: boolean; initialCode?: string }) => {
       if (!strudel.engineReady) {


### PR DESCRIPTION
Add a window keydown handler that toggles play/stop when Alt+Period is pressed to match Strudel's Alt+. binding. Use a ref for the `strudel` instance to avoid stale closures, prevent default on the shortcut, and clean up the event listener on unmount. The handler stops playback if playing, or starts playback only if the engine is ready.