### PR TITLE
Implement global Alt+. shortcut for play/stop functionality

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -159,6 +159,24 @@ export default function App() {
   // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: only re-run when session ID changes
   }, [current?.id]);
 
+  // Option+. (Alt+.) global play/stop toggle — matches strudel's Alt+. keybinding
+  const strudelRef = useRef(strudel);
+  strudelRef.current = strudel;
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.altKey && e.code === 'Period' && e.key !== '.') {
+        e.preventDefault();
+        if (strudelRef.current.isPlaying) {
+          strudelRef.current.stop();
+        } else if (strudelRef.current.engineReady) {
+          void strudelRef.current.play();
+        }
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
   const handleInstruction = useCallback(
     async (text: string, options?: { skipAddMessage?: boolean; initialCode?: string }) => {
       if (!strudel.engineReady) {


### PR DESCRIPTION
This pull request introduces a new global keyboard shortcut to the `App` component, allowing users to toggle play and stop functionality with the Alt+. (Option+.) key combination, aligning with Strudel's existing keybinding. This enhances user experience by providing a convenient, consistent way to control playback.

**Keyboard shortcut integration:**

* Added a global keydown event listener in `App` (`src/App.tsx`) to toggle play/stop when Alt+. is pressed, matching Strudel's keybinding. The handler checks if playback is active and either stops or starts playback accordingly.