### PR TITLE
Set z-index for Strudel canvas and note drawContext

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -167,6 +167,12 @@ body {
   .cm-editor .cm-lineNumbers .cm-gutterElement { font-size: 16px !important; }
 }
 
+/* Strudel full-page visualizer canvas (pianoroll, scope等) 浮于编辑器上层，pointer-events:none 不影响操作 */
+/* z-index 生效依赖 strudel 在 JS 中内联设置的 position:fixed（见 @strudel/draw draw.mjs getDrawContext）*/
+canvas#test-canvas {
+  z-index: 1;
+}
+
 canvas[id*="_widget__scope_"],
 canvas[id*="_widget__pianoroll_"],
 canvas[id*="_widget__spiral_"],

--- a/src/services/strudel.ts
+++ b/src/services/strudel.ts
@@ -152,7 +152,7 @@ class StrudelService {
         defaultOutput: webaudioOutput,
         getTime: () => getAudioContext().currentTime,
         drawTime: [0, -2],
-        drawContext: getDrawContext(),
+        drawContext: getDrawContext(), // 默认 id='test-canvas'；src/index.css 有对应 #test-canvas z-index 规则
         onUpdateState: (state: StrudelReplState) => {
           const evalError = state.evalError;
           const error = evalError


### PR DESCRIPTION
Add a CSS rule for canvas#test-canvas to ensure the Strudel full-page visualizer (pianoroll/scope/etc.) floats above the editor. The CSS comments note that pointer-events:none prevents interaction interference and that z-index only works if Strudel sets position:fixed inline (see @strudel/draw getDrawContext). Also add a brief inline comment in src/services/strudel.ts clarifying that drawContext defaults to id='test-canvas' and references the corresponding CSS rule.