### PR TITLE
Release preview

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -167,6 +167,12 @@ body {
   .cm-editor .cm-lineNumbers .cm-gutterElement { font-size: 16px !important; }
 }
 
+/* Strudel full-page visualizer canvas (pianoroll, scope等) 浮于编辑器上层，pointer-events:none 不影响操作 */
+/* z-index 生效依赖 strudel 在 JS 中内联设置的 position:fixed（见 @strudel/draw draw.mjs getDrawContext）*/
+canvas#test-canvas {
+  z-index: 1;
+}
+
 canvas[id*="_widget__scope_"],
 canvas[id*="_widget__pianoroll_"],
 canvas[id*="_widget__spiral_"],

--- a/src/services/strudel.ts
+++ b/src/services/strudel.ts
@@ -152,7 +152,7 @@ class StrudelService {
         defaultOutput: webaudioOutput,
         getTime: () => getAudioContext().currentTime,
         drawTime: [0, -2],
-        drawContext: getDrawContext(),
+        drawContext: getDrawContext(), // 默认 id='test-canvas'；src/index.css 有对应 #test-canvas z-index 规则
         onUpdateState: (state: StrudelReplState) => {
           const evalError = state.evalError;
           const error = evalError


### PR DESCRIPTION
This pull request makes a minor update to the visual layering of the Strudel full-page visualizer canvas in the application. The main change is setting a `z-index` for the `#test-canvas` element to ensure it appears above the editor without interfering with user interactions.

Visual and layering adjustments:

* Added a CSS rule for `canvas#test-canvas` to set `z-index: 1`, allowing the Strudel visualizer canvas (such as pianoroll and scope) to float above the editor while still not affecting pointer events.
* Added a clarifying comment in the `StrudelService` class to indicate that the default `drawContext` uses the `test-canvas` element, which now has an associated CSS `z-index` rule.