### PR TITLE
Feature/nova 67 fix can not play

### DIFF
--- a/src/services/strudel.ts
+++ b/src/services/strudel.ts
@@ -80,7 +80,7 @@ class StrudelService {
   }
 
   private prebake = async (): Promise<void> => {
-    const { evalScope } = await import('@strudel/core');
+    const { evalScope, Pattern, noteToMidi, valueToMidi } = await import('@strudel/core');
     const { initAudioOnFirstClick, registerSynthSounds, samples, aliasBank, getAudioContext, getSuperdoughAudioController } = await import('superdough');
 
     initAudioOnFirstClick();
@@ -109,6 +109,22 @@ class StrudelService {
     await aliasBank('https://raw.githubusercontent.com/todepond/samples/main/tidal-drum-machines-alias.json');
 
     registerSoundfonts();
+
+    // Register .piano() pattern method (from strudel packages/repl/prebake.mjs)
+    const maxPan = noteToMidi('C8');
+    const panwidth = (pan: number, width: number) => pan * width + (1 - width) / 2;
+    if (!Pattern.prototype.piano) {
+      Pattern.prototype.piano = function () {
+        return this.fmap((v: Record<string, unknown>) => ({ ...v, clip: v['clip'] ?? 1 }))
+          .s('piano')
+          .release(0.1)
+          .fmap((value: Record<string, unknown>) => {
+            const midi = valueToMidi(value);
+            const pan = panwidth(Math.min(Math.round(midi) / maxPan, 1), 0.5);
+            return { ...value, pan: ((value['pan'] as number) || 1) * pan };
+          });
+      };
+    }
 
     this.isAudioInitialized = true;
     // Expose audio hooks on window so the galaxy iframe can tap the analyser

--- a/src/types/strudel.d.ts
+++ b/src/types/strudel.d.ts
@@ -1,3 +1,9 @@
+declare module '@strudel/core' {
+  interface Pattern {
+    piano(): Pattern;
+  }
+}
+
 // Global audio context helpers registered via evalScope at runtime
 declare function getAudioContext(): AudioContext;
 declare function getSuperdoughAudioController(): { output: { destinationGain: AudioNode } } | null;


### PR DESCRIPTION
This pull request enhances the `StrudelService` by importing additional utilities from `@strudel/core` and registering a new `.piano()` pattern method on the `Pattern` prototype. The `.piano()` method enriches pattern objects with default properties and dynamic stereo panning based on MIDI note values.

Key changes:

**Feature addition:**

* Added a `.piano()` method to `Pattern.prototype` to provide a convenient way to apply piano-specific sound settings and dynamic panning based on MIDI note values. This method sets a default `clip` value, selects the `piano` sound, applies a release time, and computes the stereo pan position dynamically.

**Dependency updates:**

* Imported `Pattern`, `noteToMidi`, and `valueToMidi` from `@strudel/core` to support the new `.piano()` method and its MIDI-based computations.