### PR TITLE
Document Agent switch to setCode workflow

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -114,20 +114,14 @@ Every text message you send triggers an AI Agent inference loop:
 User text input
     ↓
 AI Agent (multi-round tool call loop, up to 30 rounds)
-    ├── getScore()                View current track structure
-    ├── addLayer(name, code)      Add a new track layer
-    ├── removeLayer(name)         Remove a track layer
-    ├── replaceLayer(name, code)  Replace track content
-    ├── applyEffect(layer, chain) Apply an effect chain to a layer
-    ├── setTempo(bpm)             Set BPM (30–240)
-    ├── improvise(role, style)    Let a sub-LLM improvise a new track
+    ├── setCode(code)             Write or modify the complete Strudel code
     ├── validate(code)            Validate code syntax and runtime
     └── commit(explanation)       Commit final code and play
     ↓
-stack(...layers) → Strudel engine executes → Browser WebAudio playback
+Strudel engine executes → Browser WebAudio playback
 ```
 
-The Agent maintains the entire piece of music as a collection of named layers. Each conversation only modifies the relevant layers while leaving the rest intact, enabling precise incremental editing.
+The Agent manages the complete Strudel code directly via `setCode`. Each conversation writes a new version, which is validated with `validate`, and finally `commit` triggers a hot-reload. Track layers are marked with `/* @layer NAME */` comments inside the code, enabling structured incremental editing.
 
 **Anyone can get started — no music theory or coding knowledge required:**
 
@@ -202,9 +196,7 @@ The Agent maintains the entire piece of music as a collection of named layers. E
 │                        │ tool calls                 │
 │    ┌───────────────────┼───────────────────┐        │
 │    ▼                   ▼                   ▼        │
-│ addLayer()       replaceLayer()       validate()    │
-│ removeLayer()    applyEffect()        improvise()   │
-│ setTempo()       getScore()           commit()      │
+│         setCode()    validate()    commit()         │
 │    └───────────────────┬───────────────────┘        │
 │                        │ final code                 │
 │               ┌────────▼────────┐                   │
@@ -225,7 +217,7 @@ See [docs/frontend-architecture.md](docs/frontend-architecture.md) for details.
 src/
 ├── App.tsx                  # Main application component
 ├── agent/
-│   ├── tools.ts             # Agent tool definitions (9 tools)
+│   ├── tools.ts             # Agent tool definitions (3 tools)
 │   ├── executor.ts          # Tool executor
 │   ├── loop.ts              # Agent inference loop (up to 30 rounds)
 │   └── parser.ts            # Strudel code parsing (layer extraction)

--- a/README.md
+++ b/README.md
@@ -115,20 +115,14 @@ npm run dev
 用户文字输入
     ↓
 AI Agent（多轮工具调用循环，最多 30 轮）
-    ├── getScore()                查看当前音轨结构
-    ├── addLayer(name, code)      添加新音轨层
-    ├── removeLayer(name)         移除音轨层
-    ├── replaceLayer(name, code)  替换音轨内容
-    ├── applyEffect(layer, chain) 为音轨叠加效果链
-    ├── setTempo(bpm)             设置 BPM（30–240）
-    ├── improvise(role, style)    让子 LLM 即兴生成新音轨
+    ├── setCode(code)             编写或修改完整 Strudel 代码
     ├── validate(code)            验证代码语法与运行时
     └── commit(explanation)       提交最终代码并播放
     ↓
-stack(...layers) → Strudel 引擎执行 → 浏览器 WebAudio 播放
+Strudel 引擎执行 → 浏览器 WebAudio 播放
 ```
 
-Agent 将整首音乐维护为多个具名 layer 的集合。每次对话只修改相关 layer，其余保持不变，实现精准的增量编辑。
+Agent 通过 `setCode` 直接管理完整的 Strudel 代码。每次对话写入新版本后经 `validate` 校验，最终 `commit` 触发热重载播放。代码内以 `/* @layer NAME */` 注释标记各音轨层，实现结构化的增量编辑。
 
 **任何人都可以上手——不需要会编曲，也不需要懂代码：**
 
@@ -145,29 +139,6 @@ Agent 将整首音乐维护为多个具名 layer 的集合。每次对话只修�
 > "加个合成器旋律，偏 ambient 风格，用 Fender Rhodes 音色"  
 > "把军鼓换成更 trap 的感觉，加 808 低音"  
 > "把整体调到 A 小调，tempo 升到 140"
-
-### 内置音乐风格
-
-| 风格 | BPM 范围 | 特色 |
-|------|---------|------|
-| lo-fi | 70–90 | 慵懒颗粒感，轻柔鼓点 |
-| house | 118–128 | 四四拍踩镲，律动贝斯线 |
-| dnb | 165–180 | 高速碎拍，深沉低频 |
-| ambient | 60–90 | 大量留白，氛围感铺垫层 |
-| techno | 125–140 | 工业感打击，循环律动 |
-| synthwave | 90–110 | 复古合成器，八十年代质感 |
-| trap | 130–160 | hi-hat 连排，808 低音 |
-| jazz | 90–110 | 摇摆律动，爵士和声 |
-| blues | 72–100 | 情感浓厚，蓝调泥土气息 |
-| funk | 90–115 | 切分节奏，极强 groove |
-| bossanova | 90–130 | 巴西轻爵士，优雅飘逸 |
-| reggae | 60–90 | 牙买加根源，off-beat 强调 |
-| classical | 60–120 | 管弦乐质感，严谨和声 |
-| rnb | 70–100 | soulful，慵懒 groove |
-| folk | 70–100 | 亲切质朴，讲故事 |
-| country | 80–130 | 美国南方根源，twangy 质感 |
-| latin | 100–135 | 拉丁热情，clave 律动 |
-| afrobeat | 92–120 | 西非律动，复调节奏感 |
 
 ## 技术栈
 
@@ -203,9 +174,7 @@ Agent 将整首音乐维护为多个具名 layer 的集合。每次对话只修�
 │                        │ tool calls                 │
 │    ┌───────────────────┼───────────────────┐        │
 │    ▼                   ▼                   ▼        │
-│ addLayer()       replaceLayer()       validate()    │
-│ removeLayer()    applyEffect()        improvise()   │
-│ setTempo()       getScore()           commit()      │
+│         setCode()    validate()    commit()         │
 │    └───────────────────┬───────────────────┘        │
 │                        │ final code                 │
 │               ┌────────▼────────┐                   │
@@ -226,7 +195,7 @@ Agent 将整首音乐维护为多个具名 layer 的集合。每次对话只修�
 src/
 ├── App.tsx                  # 应用主组件
 ├── agent/
-│   ├── tools.ts             # Agent 工具定义（9 个工具）
+│   ├── tools.ts             # Agent 工具定义（3 个工具）
 │   ├── executor.ts          # 工具执行器
 │   ├── loop.ts              # Agent 推理循环（最多 30 轮）
 │   └── parser.ts            # Strudel 代码解析（layer 提取）


### PR DESCRIPTION
Update README (EN and CN) to replace the previous multi-tool editing API with a simplified setCode/validate/commit workflow. Explain that the Agent now manages the complete Strudel code (layers marked with /* @layer NAME */), validates changes and triggers a hot-reload on commit. Remove the built-in music styles table from the Chinese README and adjust the agent tools count in the file list (9 → 3). Update diagrams and explanatory text to match the new interface.