### PR TITLE
Add TopActionBar, mobile menu and share target

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,12 +17,14 @@ import { isDemoMode, getActiveDemoSet, DEMO_PREFILL } from './demo/demo-config';
 import ApiKeyModal from './components/ApiKeyModal';
 import { hasApiKeyConfigured, getActiveModelConfig } from './services/llm-config';
 import { resetClient } from './services/llm';
-import { HistoryIcon, PlusIcon, SettingsIcon } from './components/icons';
+import { HistoryIcon, PlusIcon } from './components/icons';
+import { parseScore } from './agent/parser';
 import { useImportShare } from './hooks/useImportShare';
 import { useReplay } from './hooks/useReplay';
 import ConversationView from './components/ConversationView';
 import HistoryPanel from './components/HistoryPanel';
 import ChatInput from './components/ChatInput';
+import TopActionBar from './components/TopActionBar';
 import { trackAgentRun, trackAgentError, trackAgentAbort } from './lib/analytics';
 
 const SIDEBAR_RATIO_DEFAULT = 0.22;
@@ -135,6 +137,7 @@ export default function App() {
   // Session code = last committed/played code (used as agent context)
   // Fall back to live editor code so manually-pasted code is visible to the agent.
   const currentCode = strudel.code || (current?.code ?? '');
+  const currentBpm = parseScore(currentCode).bpm ?? 120;
   const hasUserMessages = messages.some((m) => m.role === 'user');
   const isLoading = !!current?.id && loadingSessions.has(current.id);
 
@@ -529,14 +532,18 @@ export default function App() {
             <span style={{ fontFamily: "'Baskervville', serif", fontStyle: 'italic' }}>odde</span>
             <span style={{ fontFamily: "'42dot Sans', sans-serif", fontWeight: 800 }}>Nova</span>
           </h1>
-          <button
-            onClick={() => setShowApiKeyModal(true)}
-            className="w-8 h-8 flex items-center justify-center text-text-secondary hover:text-text-primary transition-colors"
-            aria-label="设置"
-            title="设置"
-          >
-            <SettingsIcon size={18} />
-          </button>
+          <TopActionBar
+            onOpenSettings={() => setShowApiKeyModal(true)}
+            session={sessions.currentSession}
+            code={strudel.code}
+            messages={messages}
+            engineReady={strudel.engineReady}
+            hasCode={!!strudel.code}
+            exportState={strudel.exportState}
+            onExport={strudel.exportWav}
+            onResetExportState={strudel.resetExportState}
+            bpm={currentBpm}
+          />
         </div>
 
         {/* ── Conversation ── */}

--- a/src/components/TopActionBar.tsx
+++ b/src/components/TopActionBar.tsx
@@ -1,11 +1,15 @@
 import { useMemo, useState } from 'react';
 import { uploadShare } from '../services/share';
+import { shareUrl } from '../services/share-target';
 import { trackShare } from '../lib/analytics';
 import { useIsMobile } from '../hooks/useIsMobile';
+import { BookOpenIcon, DownloadIcon, GitBranchIcon, MenuIcon, SettingsIcon, ShareIcon } from './icons';
 import type { Session } from '../hooks/useSessions';
 import type { ChatMessage } from '../hooks/useChat';
 
-const zh = navigator.language.startsWith('zh');
+const zh = globalThis.navigator?.language?.startsWith('zh') ?? true;
+const learnUrl = 'https://strudel.cc/workshop/getting-started/';
+const githubUrl = 'https://github.com/yiichuan/oddeNova';
 
 // ─── Share ───────────────────────────────────────────────────────────────────
 
@@ -16,9 +20,11 @@ interface ShareButtonProps {
   code?: string;
   messages?: ChatMessage[];
   disabled?: boolean;
+  variant?: 'inline' | 'menu';
+  onShared?: () => void;
 }
 
-function ShareButton({ session, code, messages, disabled }: ShareButtonProps) {
+function ShareButton({ session, code, messages, disabled, variant = 'inline', onShared }: ShareButtonProps) {
   const [state, setState] = useState<ShareState>('idle');
 
   async function handleShare() {
@@ -26,20 +32,42 @@ function ShareButton({ session, code, messages, disabled }: ShareButtonProps) {
     if (!shareCode) return;
     setState('loading');
     try {
+      const title = session?.title?.trim() || '新会话';
       const shareId = await uploadShare({
-        title: session?.title?.trim() || '新会话',
+        title,
         code: shareCode,
         messages: session?.messages ?? messages ?? [],
       });
       const url = `${window.location.origin}/s/${shareId}`;
-      await navigator.clipboard.writeText(url);
+      await shareUrl(url);
       trackShare();
       setState('done');
+      onShared?.();
       setTimeout(() => setState('idle'), 2000);
     } catch {
       setState('error');
       setTimeout(() => setState('idle'), 3000);
     }
+  }
+
+  if (variant === 'menu') {
+    const label = state === 'loading'
+      ? (zh ? '分享中…' : 'Sharing…')
+      : state === 'error'
+        ? (zh ? '分享失败' : 'Share failed')
+        : (zh ? '分享' : 'Share');
+
+    return (
+      <button
+        type="button"
+        onClick={handleShare}
+        disabled={disabled || state === 'loading'}
+        className="mobile-menu-item disabled:opacity-35 disabled:cursor-not-allowed"
+      >
+        <span>{label}</span>
+        <ShareIcon size={19} />
+      </button>
+    );
   }
 
   return (
@@ -296,6 +324,11 @@ export default function TopActionBar({
   bpm,
 }: TopActionBarProps) {
   const [exportOpen, setExportOpen] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const isMobile = useIsMobile();
+  const actionDisabled = !engineReady || !hasCode;
+  const shareDisabled = actionDisabled || !session || exportState.status === 'exporting';
+  const exportDisabled = actionDisabled || exportState.status === 'exporting';
 
   const handleExport = async (params: ExportParams) => {
     const ok = await onExport(params);
@@ -307,6 +340,96 @@ export default function TopActionBar({
     }
     return ok;
   };
+
+  if (isMobile) {
+    return (
+      <div className="h-full relative flex items-center justify-end">
+        <button
+          type="button"
+          onClick={() => setMenuOpen((v) => !v)}
+          className="w-8 h-8 flex items-center justify-center text-text-secondary hover:text-text-primary transition-colors"
+          aria-label={zh ? '打开菜单' : 'Open menu'}
+          aria-expanded={menuOpen}
+          aria-haspopup="menu"
+          title={zh ? '菜单' : 'Menu'}
+        >
+          <MenuIcon size={20} />
+        </button>
+
+        {menuOpen && (
+          <>
+            <div className="fixed inset-0 z-30 bg-black/35 backdrop-blur-[6px]" onClick={() => setMenuOpen(false)} />
+            <div
+              role="menu"
+              className="fixed right-3 z-40 w-[min(244px,calc(100vw-24px))] rounded-[18px] border border-[#323232] bg-[#0d0d0d]/95 p-2 text-text-primary shadow-[0_18px_50px_rgba(0,0,0,0.55)] backdrop-blur-xl"
+              style={{ top: 'calc(max(12px, env(safe-area-inset-top)) + 44px)' }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => { setMenuOpen(false); onOpenSettings(); }}
+                className="mobile-menu-item"
+              >
+                <span>{zh ? '设置' : 'Settings'}</span>
+                <SettingsIcon size={19} />
+              </button>
+              <ShareButton
+                session={session}
+                code={code}
+                messages={messages}
+                disabled={shareDisabled}
+                variant="menu"
+                onShared={() => setMenuOpen(false)}
+              />
+              <button
+                type="button"
+                role="menuitem"
+                onClick={() => { setMenuOpen(false); setExportOpen(true); }}
+                disabled={exportDisabled}
+                className="mobile-menu-item disabled:opacity-35 disabled:cursor-not-allowed"
+              >
+                <span>{zh ? '导出' : 'Export'}</span>
+                <DownloadIcon size={19} />
+              </button>
+              <div className="my-2 h-px bg-white/10" />
+              <a
+                role="menuitem"
+                href={learnUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => setMenuOpen(false)}
+                className="mobile-menu-item"
+              >
+                <span>{zh ? '学习' : 'Learn'}</span>
+                <BookOpenIcon size={19} />
+              </a>
+              <a
+                role="menuitem"
+                href={githubUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => setMenuOpen(false)}
+                className="mobile-menu-item"
+              >
+                <span>GitHub</span>
+                <GitBranchIcon size={19} />
+              </a>
+            </div>
+          </>
+        )}
+
+        <ExportPopover
+          open={exportOpen}
+          onClose={() => setExportOpen(false)}
+          exportState={exportState}
+          onResetState={onResetExportState}
+          onExport={handleExport}
+          bpm={bpm}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="h-full relative flex items-center justify-end gap-3">
@@ -323,13 +446,13 @@ export default function TopActionBar({
         session={session}
         code={code}
         messages={messages}
-        disabled={!engineReady || !hasCode || !session || exportState.status === 'exporting'}
+        disabled={shareDisabled}
       />
 
       {/* 导出 */}
       <button
         onClick={() => setExportOpen((v) => !v)}
-        disabled={!engineReady || !hasCode || exportState.status === 'exporting'}
+        disabled={exportDisabled}
         className="h-7 flex items-center text-[14px] text-white/75 hover:text-white transition-colors disabled:opacity-40 disabled:cursor-not-allowed px-1.5"
       >
         {zh ? '导出' : 'Export'}
@@ -337,7 +460,7 @@ export default function TopActionBar({
 
       {/* 学习 */}
       <a
-        href="https://strudel.cc/workshop/getting-started/"
+        href={learnUrl}
         target="_blank"
         rel="noopener noreferrer"
         className="h-7 flex items-center text-[14px] text-white/75 hover:text-white transition-colors px-1.5"
@@ -347,7 +470,7 @@ export default function TopActionBar({
 
       {/* GitHub */}
       <a
-        href="https://github.com/yiichuan/oddeNova"
+        href={githubUrl}
         target="_blank"
         rel="noopener noreferrer"
         className="h-7 flex items-center text-[14px] text-white/75 hover:text-white transition-colors px-1.5"

--- a/src/components/__tests__/TopActionBar.test.tsx
+++ b/src/components/__tests__/TopActionBar.test.tsx
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { MOBILE_TOP_ACTIONS } from '../mobileTopActions';
+
+describe('TopActionBar mobile menu', () => {
+  it('keeps the requested mobile menu actions in order', () => {
+    expect(MOBILE_TOP_ACTIONS.map((action) => action.labelZh)).toEqual([
+      '设置',
+      '分享',
+      '导出',
+      '学习',
+      'GitHub',
+    ]);
+  });
+});

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -58,6 +58,35 @@ export function SettingsIcon({ size = 16, className }: IconProps) {
   );
 }
 
+export function MenuIcon({ size = 16, className }: IconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <line x1="4" y1="7" x2="20" y2="7" />
+      <line x1="4" y1="12" x2="20" y2="12" />
+      <line x1="4" y1="17" x2="20" y2="17" />
+    </svg>
+  );
+}
+
+export function BookOpenIcon({ size = 16, className }: IconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className={className}>
+      <path d="M2 4.5A2.5 2.5 0 0 1 4.5 2H11v18H4.5A2.5 2.5 0 0 0 2 22V4.5z" />
+      <path d="M22 4.5A2.5 2.5 0 0 0 19.5 2H13v18h6.5A2.5 2.5 0 0 1 22 22V4.5z" />
+    </svg>
+  );
+}
+
 export function ArrowUpIcon({ size = 16, className }: IconProps) {
   return (
     <svg

--- a/src/components/mobileTopActions.ts
+++ b/src/components/mobileTopActions.ts
@@ -1,0 +1,7 @@
+export const MOBILE_TOP_ACTIONS = [
+  { key: 'settings', labelZh: '设置', labelEn: 'Settings' },
+  { key: 'share', labelZh: '分享', labelEn: 'Share' },
+  { key: 'export', labelZh: '导出', labelEn: 'Export' },
+  { key: 'learn', labelZh: '学习', labelEn: 'Learn' },
+  { key: 'github', labelZh: 'GitHub', labelEn: 'GitHub' },
+] as const;

--- a/src/demo/__tests__/demo-config.test.ts
+++ b/src/demo/__tests__/demo-config.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../services/strudel', () => ({
+  validateCodeRuntime: vi.fn().mockReturnValue({ ok: true }),
+  validateCodeTranspiler: vi.fn().mockReturnValue({ ok: true }),
+  normalizeCode: vi.fn((code: string) => code),
+}));
+
+import { TOOLS } from '../../agent/tools';
+import {
+  DEMO_MOOD_SCENARIO,
+  DEMO_PREFILL_SCENARIO,
+  getActiveDemoSet,
+  STATIC_SUGGESTION_SCENARIOS,
+  type DemoMoodScenario,
+  type DemoScenario,
+} from '../demo-config';
+
+const availableToolNames = new Set(TOOLS.map((tool) => tool.name));
+
+function collectToolNames(scenarios: Array<DemoScenario | DemoMoodScenario>): string[] {
+  return scenarios.flatMap((scenario) =>
+    scenario.rounds.flatMap((round) => round.toolCalls.map((toolCall) => toolCall.name))
+  );
+}
+
+describe('demo tool calls', () => {
+  it('only references tools exposed by the current agent', () => {
+    const usedToolNames = collectToolNames([
+      ...getActiveDemoSet(),
+      DEMO_PREFILL_SCENARIO,
+      DEMO_MOOD_SCENARIO,
+      ...STATIC_SUGGESTION_SCENARIOS,
+    ]);
+
+    const unknownToolNames = [...new Set(usedToolNames.filter((name) => !availableToolNames.has(name)))];
+
+    expect(unknownToolNames).toEqual([]);
+  });
+});

--- a/src/demo/demo-config.ts
+++ b/src/demo/demo-config.ts
@@ -14,6 +14,25 @@ export interface DemoScenario {
   rounds: DemoRound[];
 }
 
+interface DemoLayer {
+  name: string;
+  code: string;
+  note?: string;
+}
+
+function makeScore(style: string, bpm: number, layers: DemoLayer[]): string {
+  const cps = Number((bpm / 240).toFixed(6));
+  const layerCode = layers.map((layer) => {
+    const note = layer.note ? `\n  // ${layer.note}` : '';
+    return `  /* @layer ${layer.name} */${note}\n  ${layer.code.replace(/\n/g, '\n  ')}`;
+  });
+  return `// ${style} | BPM: ${bpm}
+setcps(${cps})
+stack(
+${layerCode.join(',\n')}
+)`;
+}
+
 // ── 示例：底鼓 → 军鼓 → 氛围合成器 ──────────────────────────────────────────
 
 const _DRUMS_CODE = `s("bd*4")
@@ -33,19 +52,30 @@ const _PAD_CODE = `note("<[c3,e3,g3,b3] [f3,a3,c4,e4] [d3,f3,a3,c4] [g3,b3,d4,f4
   .delay(0.3)
   .gain(0.35)`;
 
+const _DEMO_DRUMS_SCORE = makeScore('Classic Kick', 120, [
+  { name: 'drums', code: _DRUMS_CODE, note: '四拍底鼓，每拍一下。' },
+]);
+
+const _DEMO_SNARE_SCORE = makeScore('Kick And Snare', 120, [
+  { name: 'drums', code: _DRUMS_CODE, note: '四拍底鼓保持稳定脉冲。' },
+  { name: 'sd', code: _SD_CODE, note: '军鼓落在 2、4 拍。' },
+]);
+
+const _DEMO_PAD_SCORE = makeScore('Warm Ambient Groove', 120, [
+  { name: 'drums', code: _DRUMS_CODE, note: '四拍底鼓保持稳定脉冲。' },
+  { name: 'sd', code: _SD_CODE, note: '军鼓落在 2、4 拍。' },
+  { name: 'pad', code: _PAD_CODE, note: '温暖氛围合成器铺和弦空间。' },
+]);
+
 const DEMO_SET: DemoScenario[] = [
   {
     prompt: '来个底鼓',
     rounds: [
       {
-        thinking: '好的，先来看看当前有没有已有的代码。',
-        toolCalls: [{ name: 'getScore', args: {} }],
-      },
-      {
-        thinking: '当前是空白状态，那就从零开始。4/4 拍底鼓，最经典的 four-on-the-floor 节奏。先设个默认 120 BPM，然后加一层底鼓。',
+        thinking: '4/4 拍底鼓，最经典的 four-on-the-floor 节奏。直接写完整 Strudel 代码，120 BPM，一层底鼓。',
         toolCalls: [
-          { name: 'setTempo', args: { bpm: 120 } },
-          { name: 'addLayer', args: { name: 'drums', code: _DRUMS_CODE } },
+          { name: 'setCode', args: { code: _DEMO_DRUMS_SCORE } },
+          { name: 'validate', args: {} },
         ],
       },
       {
@@ -60,13 +90,10 @@ const DEMO_SET: DemoScenario[] = [
     prompt: '加个军鼓',
     rounds: [
       {
-        thinking: '让我先看看当前的代码结构。',
-        toolCalls: [{ name: 'getScore', args: {} }],
-      },
-      {
-        thinking: '当前只有一层四拍底鼓，加一层军鼓，放在 2、4 拍上，经典的 backbeat 节奏。',
+        thinking: '保留四拍底鼓，加一层军鼓，放在 2、4 拍上，经典 backbeat 节奏。直接更新完整代码。',
         toolCalls: [
-          { name: 'addLayer', args: { name: 'sd', code: _SD_CODE } },
+          { name: 'setCode', args: { code: _DEMO_SNARE_SCORE } },
+          { name: 'validate', args: {} },
         ],
       },
       {
@@ -81,13 +108,10 @@ const DEMO_SET: DemoScenario[] = [
     prompt: '加上氛围合成器',
     rounds: [
       {
-        thinking: '让我先看看当前的代码结构，再决定怎么加氛围合成器。',
-        toolCalls: [{ name: 'getScore', args: {} }],
-      },
-      {
-        thinking: '现在有鼓和军鼓两层，120 BPM。来铺一层温暖的氛围 pad，用缓慢的和弦变化做底色，加上空间效果让它有深度感。',
+        thinking: '现在保留鼓和军鼓两层，120 BPM。再铺一层温暖氛围 pad，用缓慢和弦变化做底色，加空间效果。',
         toolCalls: [
-          { name: 'addLayer', args: { name: 'pad', code: _PAD_CODE } },
+          { name: 'setCode', args: { code: _DEMO_PAD_SCORE } },
+          { name: 'validate', args: {} },
         ],
       },
       {
@@ -126,7 +150,7 @@ const _PF_DRUMS_INITIAL = `stack(
     .lpf(6500)
     .speed(0.8)
     .pan(0.4)
-    .sometimesBy(0.3, x => x.speed(0.5))
+    .sometimes(x => x.speed(0.5))
 )
   .slow(2)`;
 
@@ -168,6 +192,13 @@ const _PF_FX = `note("<[bb5 ~ f5 ~] [~ db6 ~ ~] [~ ~ ab5 ~] [f5 ~ ~ gb5]>")
   .delayfeedback(0.45)
   .sometimes(x => x.speed("<2 0.5>"))`;
 
+const _PREFILL_SCORE = makeScore('Lo-fi Electronica', 90, [
+  { name: 'drums', code: _PF_DRUMS_INITIAL, note: '极简 IDM 鼓组，干燥底鼓、rimshot 与轻柔高频。' },
+  { name: 'bass', code: _PF_BASS, note: '深沉贝斯跟随 Bb/F 根音。' },
+  { name: 'pad', code: _PF_PAD, note: 'Rhodes 小九和弦，带 phaser 和混响。' },
+  { name: 'fx', code: _PF_FX, note: 'FM chirp 与扫频低通制造 coastal 氛围。' },
+]);
+
 export const DEMO_PREFILL_SCENARIO: DemoMoodScenario = {
   roleSnippets: {
     drums: _PF_DRUMS_INITIAL,
@@ -178,29 +209,10 @@ export const DEMO_PREFILL_SCENARIO: DemoMoodScenario = {
   rounds: [
     {
       thinking:
-        '我来构思一下这首 Lo-fi Electronica 曲目。90 BPM，coastal cinematic 氛围，以 Fender Rhodes 的 minor 9th 和弦为核心，搭配深沉的贝斯、极简 IDM 鼓点和有机的氛围纹理。先设定速度，然后从鼓骨架开始搭建。 让我先设好 BPM，然后同时草拟鼓组和 Rhodes 和弦层。',
+        '我来构思这首 Lo-fi Electronica：90 BPM，coastal cinematic 氛围，Fender Rhodes minor 9th 和弦为核心，搭配深沉贝斯、极简 IDM 鼓点和有机纹理。直接写完整代码并校验。',
       toolCalls: [
-        { name: 'setTempo', args: { bpm: 90 } },
-        { name: 'improvise', args: { role: 'drums', hints: '90 BPM, Bb minor, IDM-influenced minimalism, coastal chill vibe, dry and crisp sounds' } },
-        { name: 'improvise', args: { role: 'bass', hints: '90 BPM, Bb minor, deep and warm, acoustic bass tone, cinematic coastal feel, minimal movement' } },
-      ],
-    },
-    {
-      thinking:
-        '好的，鼓和贝斯的草稿出来了。鼓组有 808 底鼓、rimshot 和 shaker，贝斯用了 GM acoustic bass。现在继续草拟 Rhodes 和弦和氛围纹理层。',
-      toolCalls: [
-        { name: 'improvise', args: { role: 'pad', hints: '90 BPM, Bb minor, Rhodes/electric piano timbre, heavy reverb and phaser, cinematic coastal lo-fi, lush minor 9th chords' } },
-        { name: 'improvise', args: { role: 'fx', hints: '90 BPM, Bb minor, IDM-influenced organic glitches, FM chirps, sweeping LPF, experimental but chill, coastal atmosphere' } },
-      ],
-    },
-    {
-      thinking:
-        '太好了，四个层的草稿都有了。现在我来整理一下：然后把所有层添加进去。',
-      toolCalls: [
-        { name: 'addLayer', args: { name: 'drums', code: _PF_DRUMS_INITIAL } },
-        { name: 'addLayer', args: { name: 'bass', code: _PF_BASS } },
-        { name: 'addLayer', args: { name: 'pad', code: _PF_PAD } },
-        { name: 'addLayer', args: { name: 'fx', code: _PF_FX } },
+        { name: 'setCode', args: { code: _PREFILL_SCORE } },
+        { name: 'validate', args: {} },
       ],
     },
     {
@@ -227,7 +239,7 @@ export interface DemoMoodRound {
 
 export interface DemoMoodScenario {
   rounds: DemoMoodRound[];
-  /** 每个 improvise role 对应的预写片段，供自定义 improviseLLM 快速返回 */
+  /** 每个 role 对应的预写片段，供 demo UI 展示和回放使用 */
   roleSnippets: Record<string, string>;
 }
 
@@ -277,6 +289,14 @@ const _SNARE = `s("~ sd ~ sd")
   .gain(0.75)
   .room(0.2)`;
 
+const _MOOD_SCORE = makeScore('Lo-fi Mood', 82, [
+  { name: 'drums', code: _DRUMS, note: '慵懒 boom-bap 底鼓。' },
+  { name: 'snare', code: _SNARE, note: '2、4 拍军鼓补完整 backbeat。' },
+  { name: 'bass', code: _BASS, note: 'C 小调温暖低音，密度克制。' },
+  { name: 'pad', code: _PAD, note: '朦胧 juno pad 做午夜窗边感。' },
+  { name: 'hh', code: _HH, note: '稀疏摇摆高帽，增加呼吸。' },
+]);
+
 export const DEMO_MOOD_SCENARIO: DemoMoodScenario = {
   roleSnippets: {
     drums: _DRUMS,
@@ -287,42 +307,12 @@ export const DEMO_MOOD_SCENARIO: DemoMoodScenario = {
   },
   rounds: [
     {
-      thinking: '我来看看当前的状态，同时根据你的使用情况来感受一下心情氛围。',
-      toolCalls: [{ name: 'getScore', args: {} }],
-    },
-    {
       thinking:
-        '从你最近的使用来看——微信聊了一会儿、写了点代码、偶尔刷刷浏览器——感觉是那种专注工作后微微放松的状态，思绪还在转但身体已经想歇一歇了。很适合来一段 lo-fi：不快不慢，有点颗粒感，温暖又不打扰思考。 先把节奏骨架和贝斯基础打好，同步草拟。',
+        '从你最近的使用来看——微信聊了一会儿、写了点代码、偶尔刷刷浏览器——像专注工作后微微放松的状态。适合一段 lo-fi：不快不慢，有颗粒感，温暖不打扰思考。直接写完整代码并校验。',
       toolCalls: [
-        { name: 'setTempo', args: { bpm: 82 } },
-        { name: 'improvise', args: { role: 'drums', style: 'lofi', hints: '慵懒、有颗粒感、boom-bap 风格' } },
-        { name: 'improvise', args: { role: 'bass', hints: 'C minor，音符不要太密，温暖低沉' } },
+        { name: 'setCode', args: { code: _MOOD_SCORE } },
+        { name: 'validate', args: {} },
       ],
-    },
-    {
-      thinking: '节奏和低音底色有了，现在来铺一层温暖的 pad，再加一丝高帽点缀呼吸感。',
-      toolCalls: [
-        { name: 'improvise', args: { role: 'pad', hints: 'C minor，温暖朦胧，慢速和弦，像午夜窗边' } },
-        { name: 'improvise', args: { role: 'hh', hints: '不规则、有点懒散的感觉，不要太满' } },
-      ],
-    },
-    {
-      thinking: '四层都准备好了，现在一起装配进去。',
-      toolCalls: [
-        { name: 'addLayer', args: { name: 'drums', code: _DRUMS } },
-        { name: 'addLayer', args: { name: 'bass', code: _BASS } },
-        { name: 'addLayer', args: { name: 'pad', code: _PAD } },
-        { name: 'addLayer', args: { name: 'hh', code: _HH } },
-      ],
-    },
-    {
-      thinking:
-        '四层全部装配完毕，验证一下确保没有问题。drums 层里 gain 的字符串里有逗号分隔导致解析混淆，我来修正一下。',
-      toolCalls: [{ name: 'replaceLayer', args: { name: 'drums', code: _DRUMS } }],
-    },
-    {
-      thinking: '鼓层里逗号并行写法里 ~ 被误解析，改为 stack 分开两个鼓层，彻底规避这个问题。加一个 snare 层，把鼓补完整。',
-      toolCalls: [{ name: 'addLayer', args: { name: 'snare', code: _SNARE } }],
     },
     {
       thinking: '验证通过，可以提交了🎵',
@@ -524,27 +514,63 @@ const _DY_PAD = `note("<[c4,eb4,g4,bb4] [f4,ab4,c5,eb5] [bb3,d4,f4,ab4] [eb4,g4,
   .delay(0.4)
   .slow(2)`;
 
+const _CLASSICAL_MELODY = `note("<[e5 d5 c5 d5] [e5 e5 e5@2] [d5 d5 d5@2] [e5 g5 g5@2]> <[e5 d5 c5 d5] [e5 e5 e5 c5] [d5 d5 e5 d5] [c5@4]>")
+  .s("gm_piano")
+  .gain(0.6)
+  .room(1.5)
+  .delay(0.15)
+  .attack(0.01)
+  .release(0.4)`;
+
+const _CLASSICAL_BASS = `note("<[c3 e3 g3 e3] [c3 e3 g3 e3] [b2 d3 g3 d3] [c3 e3 g3 e3]> <[a2 c3 e3 c3] [a2 c3 e3 c3] [g2 b2 d3 b2] [c3 e3 g3 e3]>")
+  .s("gm_piano")
+  .gain(0.45)
+  .lpf(800)
+  .room(1.2)
+  .delay(0.1)
+  .attack(0.01)
+  .release(0.5)`;
+
+const _RETRO_GAME_SCORE = makeScore('Retro Game Clear', 105, [
+  { name: 'drums', code: _RG_DRUMS, note: '808 鼓机打底，带通关音乐的明快推进。' },
+  { name: 'bass', code: _RG_BASS, note: '方波 8-bit 贝斯线。' },
+  { name: 'lead', code: _RG_LEAD, note: '胜利感 C 大调主旋律。' },
+  { name: 'pad', code: _RG_PAD, note: '三角波闪亮琶音层。' },
+]);
+
+const _JAZZ_FUNK_SCORE = makeScore('Jazz Funk', 105, [
+  { name: 'drums', code: _JF_DRUMS, note: '切分鼓组带 swing。' },
+  { name: 'bass', code: _JF_BASS, note: 'Dm dorian 锯齿波贝斯律动。' },
+  { name: 'pad', code: _JF_PAD, note: '电钢琴和弦 stab。' },
+  { name: 'lead', code: _JF_LEAD, note: '留白小号旋律线。' },
+]);
+
+const _VIOLIN_PIANO_SCORE = makeScore('Violin And Piano', 88, [
+  { name: 'pad', code: _VP_PAD, note: 'GM 钢琴铺 C 小调和弦底色。' },
+  { name: 'lead', code: _VP_LEAD, note: '小提琴旋律线带混响和延迟。' },
+]);
+
+const _DANCE_SCORE = makeScore('Energetic House', 125, [
+  { name: 'drums', code: _DY_DRUMS, note: 'TR909 四拍鼓组。' },
+  { name: 'hh', code: _DY_HH, note: '律动 hi-hat。' },
+  { name: 'bass', code: _DY_BASS, note: '弹性锯齿波贝斯。' },
+  { name: 'pad', code: _DY_PAD, note: '温暖 pad 和声铺底。' },
+]);
+
+const _CLASSICAL_PIANO_SCORE = makeScore('Elegant Classical Piano', 88, [
+  { name: 'piano_melody', code: _CLASSICAL_MELODY, note: '右手轻盈旋律。' },
+  { name: 'piano_bass', code: _CLASSICAL_BASS, note: '左手分解和弦支撑。' },
+]);
+
 export const STATIC_SUGGESTION_SCENARIOS: DemoScenario[] = [
   {
     prompt: '来段复古游戏机通关音乐',
     rounds: [
       {
-        thinking: '好的，复古游戏机通关音乐！我想到的是 synthwave 风格，用 8-bit 感觉的方波/锯齿波合成器，节奏明快有胜利感。先看看当前有没有已有的代码。',
-        toolCalls: [{ name: 'getScore', args: {} }],
-      },
-      {
-        thinking: '从零开始，太好了。复古游戏通关音乐，BPM 105，带有胜利感的 C 大调旋律。设好速度，同时搭建鼓点和低音层。',
+        thinking: '好的，复古游戏机通关音乐！用 8-bit 感的方波/三角波合成器，节奏明快有胜利感。直接写完整代码并校验。',
         toolCalls: [
-          { name: 'setTempo', args: { bpm: 105 } },
-          { name: 'addLayer', args: { name: 'drums', code: _RG_DRUMS } },
-          { name: 'addLayer', args: { name: 'bass', code: _RG_BASS } },
-        ],
-      },
-      {
-        thinking: '鼓和贝斯骨架都有了！现在来加主旋律和闪亮的琶音层，营造胜利通关的辉煌感。',
-        toolCalls: [
-          { name: 'addLayer', args: { name: 'lead', code: _RG_LEAD } },
-          { name: 'addLayer', args: { name: 'pad', code: _RG_PAD } },
+          { name: 'setCode', args: { code: _RETRO_GAME_SCORE } },
+          { name: 'validate', args: {} },
         ],
       },
       {
@@ -559,22 +585,10 @@ export const STATIC_SUGGESTION_SCENARIOS: DemoScenario[] = [
     prompt: '来段Jazz Funk',
     rounds: [
       {
-        thinking: '好的，Jazz Funk 风格！融合爵士的和声丰富感和 Funk 的律动感，节奏偏 groovy，带点切分和 swing 的味道。先看看当前有没有已有的代码。',
-        toolCalls: [{ name: 'getScore', args: {} }],
-      },
-      {
-        thinking: '当前是空白画布。Jazz Funk BPM 105，带点 groovy 感觉。先设定速度，从鼓组骨架和贝斯线开始——Jazz Funk 的鼓要有 swing 感和切分。',
+        thinking: '好的，Jazz Funk 风格！融合爵士和声丰富感与 Funk 律动，带切分和 swing。直接写完整代码并校验。',
         toolCalls: [
-          { name: 'setTempo', args: { bpm: 105 } },
-          { name: 'addLayer', args: { name: 'drums', code: _JF_DRUMS } },
-          { name: 'addLayer', args: { name: 'bass', code: _JF_BASS } },
-        ],
-      },
-      {
-        thinking: '鼓组和贝斯骨架有了！切分感很强，Dm dorian 的 funky 走向不错。现在加 Rhodes 电钢琴和弦 stab 和小号旋律线，留白感十足。',
-        toolCalls: [
-          { name: 'addLayer', args: { name: 'pad', code: _JF_PAD } },
-          { name: 'addLayer', args: { name: 'lead', code: _JF_LEAD } },
+          { name: 'setCode', args: { code: _JAZZ_FUNK_SCORE } },
+          { name: 'validate', args: {} },
         ],
       },
       {
@@ -589,15 +603,10 @@ export const STATIC_SUGGESTION_SCENARIOS: DemoScenario[] = [
     prompt: '来首小提琴和钢琴',
     rounds: [
       {
-        thinking: '好的，让我先看看当前有没有已有的代码。',
-        toolCalls: [{ name: 'getScore', args: {} }],
-      },
-      {
-        thinking: '当前是空白画布。小提琴和钢琴组合，适合古典/抒情风格。88 BPM，先铺钢琴和弦底色，再叠小提琴旋律线，用 GM 音色获得比较真实的效果。',
+        thinking: '小提琴和钢琴组合，适合古典/抒情风格。88 BPM，钢琴和弦底色加小提琴旋律线，用 GM 音色获得比较真实的效果。',
         toolCalls: [
-          { name: 'setTempo', args: { bpm: 88 } },
-          { name: 'addLayer', args: { name: 'pad', code: _VP_PAD } },
-          { name: 'addLayer', args: { name: 'lead', code: _VP_LEAD } },
+          { name: 'setCode', args: { code: _VIOLIN_PIANO_SCORE } },
+          { name: 'validate', args: {} },
         ],
       },
       {
@@ -612,22 +621,10 @@ export const STATIC_SUGGESTION_SCENARIOS: DemoScenario[] = [
     prompt: '来点动感音乐',
     rounds: [
       {
-        thinking: '好的，来一段动感的音乐！我想做一个 house 风格的，节奏感强、律动十足。先看看当前有没有已有的代码。',
-        toolCalls: [{ name: 'getScore', args: {} }],
-      },
-      {
-        thinking: '当前是空白的。搭一个 house 风格的动感编曲，125 BPM。先定速度，从鼓组骨架和 hi-hat 节奏骨架开始。',
+        thinking: '来一段动感 house，125 BPM，四拍鼓、律动 hi-hat、弹性贝斯和温暖 pad。直接写完整代码并校验。',
         toolCalls: [
-          { name: 'setTempo', args: { bpm: 125 } },
-          { name: 'addLayer', args: { name: 'drums', code: _DY_DRUMS } },
-          { name: 'addLayer', args: { name: 'hh', code: _DY_HH } },
-        ],
-      },
-      {
-        thinking: '鼓组和 hi-hat 都有了，很有 house 的味道。接下来加一层有弹性的贝斯线和一层温暖的 pad 来填充和声。',
-        toolCalls: [
-          { name: 'addLayer', args: { name: 'bass', code: _DY_BASS } },
-          { name: 'addLayer', args: { name: 'pad', code: _DY_PAD } },
+          { name: 'setCode', args: { code: _DANCE_SCORE } },
+          { name: 'validate', args: {} },
         ],
       },
       {
@@ -642,33 +639,10 @@ export const STATIC_SUGGESTION_SCENARIOS: DemoScenario[] = [
     prompt: '来首古典优雅钢琴曲',
     rounds: [
       {
-        thinking: '好的，古典优雅的钢琴独奏，我想用一种舒缓、优美的风格来呈现。先看看当前有没有已有的代码。',
-        toolCalls: [{ name: 'getScore', args: {} }],
-      },
-      {
-        thinking: '当前是空白画布，从零开始。古典钢琴独奏，偏慢的速度（约 88 BPM），营造优雅从容的感觉。直接用两层钢琴——右手旋律 + 左手分解和弦/低音，构建一个完整的小品。先定好速度。',
+        thinking: '古典优雅钢琴独奏，88 BPM，右手旋律加左手分解和弦/低音，舒缓优美。直接写完整代码并校验。',
         toolCalls: [
-          { name: 'setTempo', args: { bpm: 88 } },
-        ],
-      },
-      {
-        thinking: '好，88 BPM，舒缓优雅。现在来加右手旋律和左手分解和弦，C 大调，带一点小调色彩的和声进行，营造古典气质。',
-        toolCalls: [
-          { name: 'addLayer', args: { name: 'piano_melody', code: `note("<[e5 d5 c5 d5] [e5 e5 e5@2] [d5 d5 d5@2] [e5 g5 g5@2]> <[e5 d5 c5 d5] [e5 e5 e5 c5] [d5 d5 e5 d5] [c5@4]>")
-  .s("gm_piano")
-  .gain(0.6)
-  .room(1.5)
-  .delay(0.15)
-  .attack(0.01)
-  .release(0.4)` } },
-          { name: 'addLayer', args: { name: 'piano_bass', code: `note("<[c3 e3 g3 e3] [c3 e3 g3 e3] [b2 d3 g3 d3] [c3 e3 g3 e3]> <[a2 c3 e3 c3] [a2 c3 e3 c3] [g2 b2 d3 b2] [c3 e3 g3 e3]>")
-  .s("gm_piano")
-  .gain(0.45)
-  .lpf(800)
-  .room(1.2)
-  .delay(0.1)
-  .attack(0.01)
-  .release(0.5)` } },
+          { name: 'setCode', args: { code: _CLASSICAL_PIANO_SCORE } },
+          { name: 'validate', args: {} },
         ],
       },
       {

--- a/src/index.css
+++ b/src/index.css
@@ -189,3 +189,27 @@ canvas[id*="_widget__spectrum_"] {
 /* Mobile: hide scrollbar on suggestion chips row */
 .no-scrollbar::-webkit-scrollbar { display: none; }
 .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
+
+.mobile-menu-item {
+  display: flex;
+  min-height: 48px;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-radius: 14px;
+  padding: 0 14px;
+  font-size: 16px;
+  line-height: 1;
+  color: rgba(212, 212, 212, 0.88);
+  transition: background-color 150ms ease, color 150ms ease;
+}
+
+.mobile-menu-item:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: #f5f5f5;
+}
+
+.mobile-menu-item:active {
+  background: rgba(255, 255, 255, 0.12);
+}

--- a/src/services/__tests__/share-target.test.ts
+++ b/src/services/__tests__/share-target.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { shareUrl } from '../share-target';
+
+describe('shareUrl', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('copies with Clipboard API without opening native share', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const nativeShare = vi.fn().mockResolvedValue(undefined);
+
+    vi.stubGlobal('navigator', {
+      clipboard: { writeText },
+      share: nativeShare,
+    });
+
+    await expect(shareUrl('https://www.oddenova.com/s/abc123')).resolves.toBe('copied');
+    expect(writeText).toHaveBeenCalledWith('https://www.oddenova.com/s/abc123');
+    expect(nativeShare).not.toHaveBeenCalled();
+  });
+
+  it('falls back to legacy copy when Clipboard API is unavailable', async () => {
+    const appended: unknown[] = [];
+    const removed: unknown[] = [];
+    const textarea = {
+      value: '',
+      setAttribute: vi.fn(),
+      select: vi.fn(),
+      style: {},
+    };
+
+    vi.stubGlobal('navigator', {});
+    vi.stubGlobal('document', {
+      createElement: vi.fn(() => textarea),
+      execCommand: vi.fn(() => true),
+      body: {
+        appendChild: vi.fn((node: unknown) => appended.push(node)),
+        removeChild: vi.fn((node: unknown) => removed.push(node)),
+      },
+    });
+
+    await expect(shareUrl('http://192.168.0.112/s/abc123')).resolves.toBe('copied');
+    expect(textarea.value).toBe('http://192.168.0.112/s/abc123');
+    expect(textarea.select).toHaveBeenCalled();
+    expect(document.execCommand).toHaveBeenCalledWith('copy');
+    expect(appended).toEqual([textarea]);
+    expect(removed).toEqual([textarea]);
+  });
+});

--- a/src/services/share-target.ts
+++ b/src/services/share-target.ts
@@ -1,0 +1,36 @@
+export type ShareTargetResult = 'copied';
+
+function legacyCopy(text: string): boolean {
+  if (typeof document === 'undefined' || !document.body) return false;
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.top = '-9999px';
+  textarea.style.left = '-9999px';
+
+  document.body.appendChild(textarea);
+  textarea.select();
+  try {
+    return document.execCommand('copy');
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
+export async function shareUrl(url: string): Promise<ShareTargetResult> {
+  const nav = globalThis.navigator;
+
+  if (nav?.clipboard?.writeText) {
+    try {
+      await nav.clipboard.writeText(url);
+      return 'copied';
+    } catch {
+      // Fall through to the legacy path for insecure localhost/IP previews.
+    }
+  }
+
+  if (legacyCopy(url)) return 'copied';
+
+  throw new Error('Share target unavailable');
+}


### PR DESCRIPTION
Integrate a new TopActionBar into App.tsx (replacing the single settings button) and pass bpm parsed from current score. Implement a full TopActionBar component with desktop actions and a mobile menu, share/export/learn/GitHub items, and improved share flow using a new share-target service (shareUrl). Add MenuIcon and BookOpenIcon, mobile menu styles in index.css, and mobileTopActions constant for ordering (with tests). Refactor demo-config to use a makeScore helper and consolidated setCode/validate flows for demo scenarios, adding multiple preset scores and tests to ensure demo tool calls reference available tools. Include tests for share-target and TopActionBar mobile menu behavior.