### PR TITLE
Add share fallbacks and error logging

### DIFF
--- a/src/components/TopActionBar.tsx
+++ b/src/components/TopActionBar.tsx
@@ -44,7 +44,8 @@ function ShareButton({ session, code, messages, disabled, variant = 'inline', on
       setState('done');
       onShared?.();
       setTimeout(() => setState('idle'), 2000);
-    } catch {
+    } catch (error) {
+      console.error('[share] Failed to create or open share target', error);
       setState('error');
       setTimeout(() => setState('idle'), 3000);
     }

--- a/src/services/__tests__/share-target.test.ts
+++ b/src/services/__tests__/share-target.test.ts
@@ -47,4 +47,54 @@ describe('shareUrl', () => {
     expect(appended).toEqual([textarea]);
     expect(removed).toEqual([textarea]);
   });
+
+  it('falls back to native share when clipboard copy is unavailable', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('NotAllowedError'));
+    const nativeShare = vi.fn().mockResolvedValue(undefined);
+
+    vi.stubGlobal('navigator', {
+      clipboard: { writeText },
+      share: nativeShare,
+    });
+    vi.stubGlobal('document', {
+      createElement: vi.fn(() => ({
+        value: '',
+        setAttribute: vi.fn(),
+        select: vi.fn(),
+        style: {},
+      })),
+      execCommand: vi.fn(() => false),
+      body: {
+        appendChild: vi.fn(),
+        removeChild: vi.fn(),
+      },
+    });
+
+    await expect(shareUrl('https://www.oddenova.com/s/abc123')).resolves.toBe('shared');
+    expect(writeText).toHaveBeenCalledWith('https://www.oddenova.com/s/abc123');
+    expect(nativeShare).toHaveBeenCalledWith({ url: 'https://www.oddenova.com/s/abc123' });
+  });
+
+  it('shows the share URL when automatic share targets are unavailable', async () => {
+    const prompt = vi.fn();
+
+    vi.stubGlobal('navigator', {});
+    vi.stubGlobal('document', {
+      createElement: vi.fn(() => ({
+        value: '',
+        setAttribute: vi.fn(),
+        select: vi.fn(),
+        style: {},
+      })),
+      execCommand: vi.fn(() => false),
+      body: {
+        appendChild: vi.fn(),
+        removeChild: vi.fn(),
+      },
+    });
+    vi.stubGlobal('prompt', prompt);
+
+    await expect(shareUrl('http://192.168.0.112/s/abc123')).resolves.toBe('shown');
+    expect(prompt).toHaveBeenCalledWith('复制分享链接', 'http://192.168.0.112/s/abc123');
+  });
 });

--- a/src/services/share-target.ts
+++ b/src/services/share-target.ts
@@ -1,4 +1,4 @@
-export type ShareTargetResult = 'copied';
+export type ShareTargetResult = 'copied' | 'shared' | 'shown';
 
 function legacyCopy(text: string): boolean {
   if (typeof document === 'undefined' || !document.body) return false;
@@ -32,5 +32,17 @@ export async function shareUrl(url: string): Promise<ShareTargetResult> {
 
   if (legacyCopy(url)) return 'copied';
 
-  throw new Error('Share target unavailable');
+  if (nav?.share) {
+    await nav.share({ url });
+    return 'shared';
+  }
+
+  if (typeof globalThis.prompt === 'function') {
+    globalThis.prompt('复制分享链接', url);
+    return 'shown';
+  }
+
+  throw new Error(
+    `Share target unavailable: clipboard=${Boolean(nav?.clipboard?.writeText)}, nativeShare=${Boolean(nav?.share)}, prompt=false`
+  );
 }


### PR DESCRIPTION
Extend share behavior and tests: update share-target to return 'shared' or 'shown' and try navigator.share when clipboard copy fails, falling back to a prompt before throwing a detailed error. Add tests covering native-share and prompt fallbacks. Also log errors in TopActionBar catch block to aid debugging when share creation/opening fails.