### PR TITLE
Add official proxy endpoint and update config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,9 @@ VITE_LLM_MODEL=
 # Vercel Deployment (server-side only, NOT exposed to the browser)
 # ============================================================
 
+# Official experience API key — used by /api/official/* before VITE_API_KEY
+OFFICIAL_API_KEY=
+
 # Required for the /api/cleanup cron job authentication
 # Generate with: openssl rand -hex 32
 CRON_SECRET=

--- a/api/official/v1/chat/completions.ts
+++ b/api/official/v1/chat/completions.ts
@@ -1,0 +1,66 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+const DEEPSEEK_CHAT_COMPLETIONS_URL = 'https://api.deepseek.com/v1/chat/completions';
+
+function resolveOfficialApiKey(): string {
+  return process.env.OFFICIAL_API_KEY || process.env.VITE_API_KEY || '';
+}
+
+async function writeStream(response: Response, res: VercelResponse): Promise<void> {
+  res.setHeader('Content-Type', response.headers.get('content-type') || 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache, no-transform');
+  res.setHeader('Connection', 'keep-alive');
+
+  if (!response.body) {
+    res.end();
+    return;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    res.write(decoder.decode(value, { stream: true }));
+  }
+
+  const tail = decoder.decode();
+  if (tail) res.write(tail);
+  res.end();
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const apiKey = resolveOfficialApiKey();
+  if (!apiKey) {
+    res.status(500).json({ error: 'OFFICIAL_API_KEY or VITE_API_KEY is not configured' });
+    return;
+  }
+
+  try {
+    const upstream = await fetch(DEEPSEEK_CHAT_COMPLETIONS_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(req.body ?? {}),
+    });
+
+    if (req.body && typeof req.body === 'object' && 'stream' in req.body && req.body.stream) {
+      await writeStream(upstream, res);
+      return;
+    }
+
+    const contentType = upstream.headers.get('content-type');
+    if (contentType) res.setHeader('Content-Type', contentType);
+    res.status(upstream.status).end(await upstream.text());
+  } catch (_error) {
+    res.status(502).json({ error: 'Official provider request failed' });
+  }
+}

--- a/src/services/__tests__/llm-config.test.ts
+++ b/src/services/__tests__/llm-config.test.ts
@@ -13,6 +13,9 @@ function installLocalStorage(): void {
 
 beforeEach(() => {
   vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  vi.stubEnv('VITE_API_KEY', '');
+  vi.stubEnv('VITE_BASE_URL', '');
   installLocalStorage();
 });
 
@@ -64,7 +67,11 @@ describe('PROVIDER_PRESETS', () => {
     expect(['anthropic', 'openai']).toContain(protocol);
   });
 
-  it.each(expectedProviders)('"%s" baseURL starts with https://', (provider) => {
+  it.each(expectedProviders)('"%s" baseURL uses the expected transport', (provider) => {
+    if (provider === 'official') {
+      expect(PROVIDER_PRESETS[provider].baseURL).toMatch(/^\/api\//);
+      return;
+    }
     expect(PROVIDER_PRESETS[provider].baseURL).toMatch(/^https:\/\//);
   });
 });
@@ -75,24 +82,23 @@ describe('official provider API key defaults', () => {
     expect(hasApiKeyConfigured()).toBe(true);
   });
 
-  it('uses DeepSeek directly and keeps a placeholder API key when no key is saved', () => {
+  it('uses the same-origin official proxy and a placeholder API key', () => {
     localStorage.setItem('vibe_provider', 'official');
 
     const cfg = getActiveModelConfig();
 
     expect(cfg.provider).toBe('official');
-    expect(cfg.baseURL).toBe('https://api.deepseek.com/v1');
+    expect(cfg.baseURL).toBe('/api/official/v1');
     expect(cfg.apiKey).toBe('official-proxy');
   });
 
-  it('uses a saved key for official debugging without changing the provider default', () => {
+  it('expands official proxy baseURL to the current origin in browsers', () => {
     localStorage.setItem('vibe_provider', 'official');
-    localStorage.setItem('vibe_api_key', 'sk-debug');
+    vi.stubGlobal('window', {
+      location: { origin: 'https://www.oddenova.com' },
+    });
 
-    const cfg = getActiveModelConfig();
-
-    expect(cfg.baseURL).toBe('https://api.deepseek.com/v1');
-    expect(cfg.apiKey).toBe('sk-debug');
+    expect(getActiveModelConfig().baseURL).toBe('https://www.oddenova.com/api/official/v1');
   });
 
   it('still requires a user key for non-official providers', () => {

--- a/src/services/__tests__/official-chat-completions.test.ts
+++ b/src/services/__tests__/official-chat-completions.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import handler from '../../../api/official/v1/chat/completions';
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+function makeReq(method: string, body?: unknown): VercelRequest {
+  return { method, body, headers: {} } as VercelRequest;
+}
+
+interface TestResponse {
+  statusCodeValue?: number;
+  jsonBody?: unknown;
+  sentHeaders: Record<string, string>;
+  chunks: unknown[];
+  status: (code: number) => TestResponse;
+  json: (body: unknown) => TestResponse;
+  setHeader: (name: string, value: string) => TestResponse;
+  write: (chunk: unknown) => boolean;
+  end: (chunk?: unknown) => TestResponse;
+}
+
+function makeRes(): TestResponse {
+  const res: TestResponse = {
+    sentHeaders: {},
+    chunks: [],
+    status(code: number) {
+      this.statusCodeValue = code;
+      return this;
+    },
+    json(body: unknown) {
+      this.jsonBody = body;
+      return this;
+    },
+    setHeader(name: string, value: string) {
+      this.sentHeaders[name.toLowerCase()] = value;
+      return this;
+    },
+    write(chunk: unknown) {
+      this.chunks.push(chunk);
+      return true;
+    },
+    end(chunk?: unknown) {
+      if (chunk) this.chunks.push(chunk);
+      return this;
+    },
+  };
+  return res;
+}
+
+describe('/api/official/v1/chat/completions', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    delete process.env.OFFICIAL_API_KEY;
+    delete process.env.VITE_API_KEY;
+  });
+
+  it('returns 405 for non-POST requests', async () => {
+    const res = makeRes();
+
+    await handler(makeReq('GET'), res as unknown as VercelResponse);
+
+    expect(res.statusCodeValue).toBe(405);
+    expect(res.jsonBody).toEqual({ error: 'Method not allowed' });
+  });
+
+  it('returns 500 when no official key fallback is configured', async () => {
+    const res = makeRes();
+
+    await handler(makeReq('POST', { stream: false }), res as unknown as VercelResponse);
+
+    expect(res.statusCodeValue).toBe(500);
+    expect(res.jsonBody).toEqual({ error: 'OFFICIAL_API_KEY or VITE_API_KEY is not configured' });
+  });
+
+  it('prefers OFFICIAL_API_KEY over VITE_API_KEY', async () => {
+    process.env.OFFICIAL_API_KEY = 'sk-official';
+    process.env.VITE_API_KEY = 'sk-vite';
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      text: () => Promise.resolve('{"ok":true}'),
+    }));
+
+    await handler(makeReq('POST', { stream: false }), makeRes() as unknown as VercelResponse);
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.deepseek.com/v1/chat/completions',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer sk-official' }),
+      }),
+    );
+  });
+
+  it('falls back to VITE_API_KEY when OFFICIAL_API_KEY is unavailable', async () => {
+    process.env.VITE_API_KEY = 'sk-vite';
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      text: () => Promise.resolve('{"ok":true}'),
+    }));
+
+    await handler(makeReq('POST', { stream: false }), makeRes() as unknown as VercelResponse);
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.deepseek.com/v1/chat/completions',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer sk-vite' }),
+      }),
+    );
+  });
+
+  it('proxies streaming responses as text/event-stream', async () => {
+    process.env.OFFICIAL_API_KEY = 'sk-official';
+    const upstream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('data: {"ok":true}\n\n'));
+        controller.close();
+      },
+    });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ 'content-type': 'text/event-stream' }),
+      body: upstream,
+    }));
+    const res = makeRes();
+
+    await handler(makeReq('POST', { stream: true }), res as unknown as VercelResponse);
+
+    expect(res.sentHeaders['content-type']).toBe('text/event-stream');
+    expect(res.chunks.join('')).toContain('data: {"ok":true}');
+  });
+});

--- a/src/services/llm-config.ts
+++ b/src/services/llm-config.ts
@@ -6,7 +6,7 @@
 //   deepseek   → api.deepseek.com + 内置模型 + localStorage vibe_api_key
 //   kimi       → api.moonshot.cn  + 内置模型 + localStorage vibe_api_key
 //   openai     → api.openai.com   + 内置模型 + localStorage vibe_api_key
-//   official   → api.deepseek.com + 内置模型 + 调试 Key（如有）或占位 Key
+//   official   → /api/official/v1 + 内置模型 + 服务端 OFFICIAL_API_KEY / VITE_API_KEY
 //   glm        → open.bigmodel.cn + 内置模型 + localStorage vibe_api_key
 //   未设置     → official
 // ===========================================================================
@@ -62,7 +62,7 @@ export const PROVIDER_PRESETS: Record<ProviderType, ProviderPreset> = {
   },
   official: {
     label: '官方体验',
-    baseURL: 'https://api.deepseek.com/v1',
+    baseURL: '/api/official/v1',
     model: 'deepseek-v4-pro',
     protocol: 'openai',
   },
@@ -118,10 +118,15 @@ function resolveOpenAICompatConfig(
   return {
     provider,
     protocol: 'openai',
-    apiKey: isOfficial ? (apiKey || 'official-proxy') : apiKey,
-    baseURL: import.meta.env.VITE_BASE_URL || preset.baseURL,
+    apiKey: isOfficial ? 'official-proxy' : apiKey,
+    baseURL: isOfficial ? resolveOfficialBaseURL() : (import.meta.env.VITE_BASE_URL || preset.baseURL),
     model:   preset.model,
   };
+}
+
+function resolveOfficialBaseURL(): string {
+  if (typeof window === 'undefined') return PROVIDER_PRESETS.official.baseURL;
+  return `${window.location.origin}${PROVIDER_PRESETS.official.baseURL}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -154,11 +159,7 @@ export function getActiveModelConfig(): ModelConfig {
   }
 
   if (provider === 'official') {
-    const officialDebugKey =
-      import.meta.env.VITE_API_KEY ||
-      localStorage.getItem('vibe_api_key') ||
-      '';
-    return resolveOpenAICompatConfig(provider, officialDebugKey);
+    return resolveOpenAICompatConfig(provider, 'official-proxy');
   }
 
   // 其他 provider 使用用户在 Modal 里填的 Key


### PR DESCRIPTION
Introduce a server-side official proxy and wire it into the official provider config.

- Add OFFICIAL_API_KEY to .env.example for a server-only official key.
- Add api/official/v1/chat/completions.ts: a Vercel handler that proxies POST requests to DeepSeek, prefers OFFICIAL_API_KEY over VITE_API_KEY, and supports streaming responses (text/event-stream).
- Update src/services/llm-config.ts: change the official provider baseURL to /api/official/v1, use a placeholder apiKey ('official-proxy') for browsers, and expand the proxy baseURL to the current origin at runtime. This avoids exposing server keys while routing official traffic via the same-origin proxy.
- Update tests: adjust llm-config tests for the new proxy behavior and env stubbing, and add official-chat-completions.test.ts to cover handler behavior (method checks, key resolution, and streaming proxying).

These changes enable using a server-held official API key for the official experience without exposing it to the browser, while preserving developer debug flows.