### PR TITLE
Add share-page tests and resilient handler

### DIFF
--- a/api/share-page.test.ts
+++ b/api/share-page.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import handler from './share-page';
+import { list } from '@vercel/blob';
+
+vi.mock('@vercel/blob', () => ({
+  list: vi.fn(),
+}));
+
+const appShell = `<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta name="description" content="old description" />
+    <meta property="og:title" content="old title" />
+    <meta property="og:description" content="old og description" />
+    <meta property="og:url" content="https://oddenova.com/" />
+    <meta property="og:image" content="https://oddenova.com/old.png" />
+    <meta name="twitter:title" content="old twitter title" />
+    <meta name="twitter:description" content="old twitter description" />
+    <meta name="twitter:image" content="https://oddenova.com/old.png" />
+    <title>old page title</title>
+  </head>
+  <body><div id="root"></div></body>
+</html>`;
+
+function makeResponse() {
+  return {
+    statusCode: 0,
+    body: '',
+    headers: {} as Record<string, string>,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    send(body: string) {
+      this.body = body;
+      return this;
+    },
+    setHeader(name: string, value: string) {
+      this.headers[name] = value;
+    },
+  };
+}
+
+describe('share-page handler', () => {
+  beforeEach(() => {
+    vi.mocked(list).mockReset();
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(appShell, { status: 200 })));
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('renders fallback share HTML when blob lookup fails', async () => {
+    vi.mocked(list).mockRejectedValue(new Error('missing blob token'));
+    const res = makeResponse();
+
+    await handler({
+      method: 'GET',
+      query: { id: 'abc123' },
+      headers: { host: 'www.oddenova.com', 'x-forwarded-proto': 'https' },
+    } as never, res as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['Content-Type']).toBe('text/html; charset=utf-8');
+    expect(res.body).toContain('property="og:url" content="https://www.oddenova.com/s/abc123"');
+    expect(res.body).toContain('content="oddeNova | Vibe Your Live Music"');
+  });
+});

--- a/api/share-page.ts
+++ b/api/share-page.ts
@@ -3,10 +3,58 @@ import { list } from '@vercel/blob';
 import { renderShareHtml } from '../src/services/share-page-meta';
 import type { SharePayload } from '../src/services/share';
 
+const FALLBACK_APP_SHELL = `<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="description" content="" />
+    <meta property="og:title" content="" />
+    <meta property="og:description" content="" />
+    <meta property="og:url" content="" />
+    <meta property="og:image" content="" />
+    <meta name="twitter:title" content="" />
+    <meta name="twitter:description" content="" />
+    <meta name="twitter:image" content="" />
+    <title>oddeNova</title>
+  </head>
+  <body><div id="root"></div></body>
+</html>`;
+
 function getRequestOrigin(req: VercelRequest): string {
   const proto = String(req.headers['x-forwarded-proto'] ?? 'https').split(',')[0];
   const host = req.headers.host;
   return `${proto}://${host}`;
+}
+
+async function fetchAppShell(origin: string): Promise<string> {
+  try {
+    const indexRes = await fetch(`${origin}/`);
+    if (indexRes.ok) {
+      return indexRes.text();
+    }
+    console.error(`[share-page] Failed to fetch app shell: ${indexRes.status}`);
+  } catch (error) {
+    console.error('[share-page] Failed to fetch app shell', error);
+  }
+  return FALLBACK_APP_SHELL;
+}
+
+async function sendShareHtml(
+  req: VercelRequest,
+  res: VercelResponse,
+  id: string,
+  locale?: SharePayload['locale'],
+) {
+  const origin = getRequestOrigin(req);
+  const html = renderShareHtml(await fetchAppShell(origin), {
+    locale,
+    url: `${origin}/s/${encodeURIComponent(id)}`,
+  });
+
+  res.setHeader('Content-Type', 'text/html; charset=utf-8');
+  res.setHeader('Cache-Control', 'public, max-age=0, s-maxage=300');
+  res.status(200).send(html);
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -21,7 +69,15 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return;
   }
 
-  const { blobs } = await list({ prefix: `shares/${id}.json`, limit: 1 });
+  let blobs: Awaited<ReturnType<typeof list>>['blobs'];
+  try {
+    ({ blobs } = await list({ prefix: `shares/${id}.json`, limit: 1 }));
+  } catch (error) {
+    console.error('[share-page] Failed to lookup share blob', error);
+    await sendShareHtml(req, res, id);
+    return;
+  }
+
   if (blobs.length === 0) {
     res.status(404).send('Not found');
     return;
@@ -29,24 +85,19 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   const blobRes = await fetch(blobs[0].url);
   if (!blobRes.ok) {
-    res.status(502).send('Failed to fetch share');
+    console.error(`[share-page] Failed to fetch share blob: ${blobRes.status}`);
+    await sendShareHtml(req, res, id);
     return;
   }
 
-  const payload = (await blobRes.json()) as SharePayload;
-  const origin = getRequestOrigin(req);
-  const indexRes = await fetch(`${origin}/`);
-  if (!indexRes.ok) {
-    res.status(502).send('Failed to fetch app shell');
+  let payload: SharePayload;
+  try {
+    payload = (await blobRes.json()) as SharePayload;
+  } catch (error) {
+    console.error('[share-page] Failed to parse share blob', error);
+    await sendShareHtml(req, res, id);
     return;
   }
 
-  const html = renderShareHtml(await indexRes.text(), {
-    locale: payload.locale,
-    url: `${origin}/s/${encodeURIComponent(id)}`,
-  });
-
-  res.setHeader('Content-Type', 'text/html; charset=utf-8');
-  res.setHeader('Cache-Control', 'public, max-age=0, s-maxage=300');
-  res.status(200).send(html);
+  await sendShareHtml(req, res, id, payload.locale);
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'api/**/*.{test,spec}.{ts,tsx}'],
   },
 });


### PR DESCRIPTION
Add a unit test for the share-page handler that verifies fallback HTML is rendered when blob lookup fails. Refactor the handler to be more resilient: introduce a FALLBACK_APP_SHELL, fetchAppShell and sendShareHtml helpers, add try/catch around blob list lookup and JSON parsing, log errors, and fall back to rendering the app shell when blob fetch/parse fails. Ensure response headers (Content-Type and Cache-Control) are set consistently. Also update vitest config to include tests under the api/ directory.