### PR TITLE
Inline share-page metadata renderer and test

### DIFF
--- a/api/share-page.test.ts
+++ b/api/share-page.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import handler from './share-page';
 import { list } from '@vercel/blob';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 vi.mock('@vercel/blob', () => ({
   list: vi.fn(),
@@ -67,5 +69,11 @@ describe('share-page handler', () => {
     expect(res.headers['Content-Type']).toBe('text/html; charset=utf-8');
     expect(res.body).toContain('property="og:url" content="https://www.oddenova.com/s/abc123"');
     expect(res.body).toContain('content="oddeNova | Vibe Your Live Music"');
+  });
+
+  it('does not depend on client src modules at runtime', () => {
+    const source = readFileSync(fileURLToPath(new URL('./share-page.ts', import.meta.url)), 'utf8');
+
+    expect(source).not.toContain('../src/');
   });
 });

--- a/api/share-page.ts
+++ b/api/share-page.ts
@@ -1,7 +1,19 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { list } from '@vercel/blob';
-import { renderShareHtml } from '../src/services/share-page-meta';
-import type { SharePayload } from '../src/services/share';
+
+type ShareLocale = 'zh-CN' | 'en';
+
+interface SharePayload {
+  locale?: ShareLocale;
+}
+
+const SHARE_TITLE = 'oddeNova | Vibe Your Live Music';
+const SHARE_IMAGE = 'https://oddenova.com/oddenova-og.png';
+
+const SHARE_DESCRIPTIONS: Record<ShareLocale, string> = {
+  'zh-CN': '即兴 vibe 音乐，让灵感，自由发声',
+  en: 'Vibes in your head -> Music in your ears',
+};
 
 const FALLBACK_APP_SHELL = `<!doctype html>
 <html lang="zh-CN">
@@ -25,6 +37,41 @@ function getRequestOrigin(req: VercelRequest): string {
   const proto = String(req.headers['x-forwarded-proto'] ?? 'https').split(',')[0];
   const host = req.headers.host;
   return `${proto}://${host}`;
+}
+
+function normalizeLocale(locale: unknown): ShareLocale {
+  return locale === 'en' ? 'en' : 'zh-CN';
+}
+
+function escapeHtmlAttr(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
+function replaceMeta(html: string, selector: string, value: string): string {
+  const escaped = escapeHtmlAttr(value);
+  const pattern = new RegExp(`(<meta\\b(?=[^>]*${selector})[^>]*\\bcontent=")[^"]*("[^>]*>)`, 'i');
+  return html.replace(pattern, `$1${escaped}$2`);
+}
+
+function renderShareHtml(html: string, options: { locale?: ShareLocale; url: string }): string {
+  const locale = normalizeLocale(options.locale);
+  const description = SHARE_DESCRIPTIONS[locale];
+
+  let out = html.replace(/<html\b[^>]*>/i, `<html lang="${locale}">`);
+  out = out.replace(/<title>.*?<\/title>/i, `<title>${SHARE_TITLE}</title>`);
+  out = replaceMeta(out, 'name="description"', description);
+  out = replaceMeta(out, 'property="og:title"', SHARE_TITLE);
+  out = replaceMeta(out, 'property="og:description"', description);
+  out = replaceMeta(out, 'property="og:url"', options.url);
+  out = replaceMeta(out, 'property="og:image"', SHARE_IMAGE);
+  out = replaceMeta(out, 'name="twitter:title"', SHARE_TITLE);
+  out = replaceMeta(out, 'name="twitter:description"', description);
+  out = replaceMeta(out, 'name="twitter:image"', SHARE_IMAGE);
+  return out;
 }
 
 async function fetchAppShell(origin: string): Promise<string> {


### PR DESCRIPTION
Remove runtime dependency on ../src by inlining renderShareHtml and related types/constants into api/share-page.ts. Implement locale normalization, HTML-attribute escaping, and meta replacement logic; add share title/image/descriptions constants. Add a unit test to ensure the API file does not reference client src modules at runtime. This keeps share-page self-contained for server execution and prevents bundling client code into the server lambda.