### PR TITLE
Update share metadata and meta insertion

### DIFF
--- a/api/share-page.test.ts
+++ b/api/share-page.test.ts
@@ -68,6 +68,8 @@ describe('share-page handler', () => {
     expect(res.statusCode).toBe(200);
     expect(res.headers['Content-Type']).toBe('text/html; charset=utf-8');
     expect(res.body).toContain('property="og:url" content="https://www.oddenova.com/s/abc123"');
+    expect(res.body).toContain('property="og:image" content="https://www.oddenova.com/oddenova-og.png?v=c1189f30"');
+    expect(res.body).toContain('name="twitter:image" content="https://www.oddenova.com/oddenova-og.png?v=c1189f30"');
     expect(res.body).toContain('content="oddeNova | Vibe Your Live Music"');
   });
 

--- a/api/share-page.ts
+++ b/api/share-page.ts
@@ -8,11 +8,11 @@ interface SharePayload {
 }
 
 const SHARE_TITLE = 'oddeNova | Vibe Your Live Music';
-const SHARE_IMAGE = 'https://oddenova.com/oddenova-og.png';
+const SHARE_IMAGE = 'https://www.oddenova.com/oddenova-og.png?v=c1189f30';
 
 const SHARE_DESCRIPTIONS: Record<ShareLocale, string> = {
   'zh-CN': '即兴 vibe 音乐，让灵感，自由发声',
-  en: 'Vibes in your head -> Music in your ears',
+  en: 'Plain text in, rich music out',
 };
 
 const FALLBACK_APP_SHELL = `<!doctype html>
@@ -54,7 +54,11 @@ function escapeHtmlAttr(value: string): string {
 function replaceMeta(html: string, selector: string, value: string): string {
   const escaped = escapeHtmlAttr(value);
   const pattern = new RegExp(`(<meta\\b(?=[^>]*${selector})[^>]*\\bcontent=")[^"]*("[^>]*>)`, 'i');
-  return html.replace(pattern, `$1${escaped}$2`);
+  const replaced = html.replace(pattern, `$1${escaped}$2`);
+  if (replaced !== html) {
+    return replaced;
+  }
+  return html.replace(/<\/head>/i, `    <meta ${selector} content="${escaped}" />\n  </head>`);
 }
 
 function renderShareHtml(html: string, options: { locale?: ShareLocale; url: string }): string {

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta
       name="description"
-      content="Vibes in your head -> Music in your ears"
+      content="Plain text in, rich music out"
     />
     <meta name="robots" content="index, follow" />
     <meta name="application-name" content="oddeNova" />
@@ -17,20 +17,20 @@
     <meta property="og:title" content="oddeNova | Vibe Your Live Music" />
     <meta
       property="og:description"
-      content="Vibes in your head -> Music in your ears"
+      content="Plain text in, rich music out"
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://oddenova.com/" />
     <meta property="og:site_name" content="oddeNova" />
-    <meta property="og:image" content="https://oddenova.com/oddenova-og.png" />
+    <meta property="og:image" content="https://www.oddenova.com/oddenova-og.png?v=c1189f30" />
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="oddeNova | Vibe Your Live Music" />
     <meta
       name="twitter:description"
-      content="Vibes in your head -> Music in your ears"
+      content="Plain text in, rich music out"
     />
-    <meta name="twitter:image" content="https://oddenova.com/oddenova-og.png" />
+    <meta name="twitter:image" content="https://www.oddenova.com/oddenova-og.png?v=c1189f30" />
 
     <script type="application/ld+json">
       {
@@ -40,9 +40,9 @@
         "url": "https://oddenova.com/",
         "applicationCategory": "MultimediaApplication",
         "operatingSystem": "Web",
-        "description": "Vibes in your head -> Music in your ears",
+        "description": "Plain text in, rich music out",
         "inLanguage": ["zh-CN", "en"],
-        "image": "https://oddenova.com/oddenova-og.png",
+        "image": "https://www.oddenova.com/oddenova-og.png?v=c1189f30",
         "offers": {
           "@type": "Offer",
           "price": "0",

--- a/src/services/__tests__/share-page-meta.test.ts
+++ b/src/services/__tests__/share-page-meta.test.ts
@@ -35,6 +35,8 @@ describe('renderShareHtml', () => {
     expect(html).toContain('content="oddeNova | Vibe Your Live Music"');
     expect(html).toContain('content="即兴 vibe 音乐，让灵感，自由发声"');
     expect(html).toContain('property="og:url" content="https://oddenova.com/s/abc123"');
+    expect(html).toContain('property="og:image" content="https://www.oddenova.com/oddenova-og.png?v=c1189f30"');
+    expect(html).toContain('name="twitter:image" content="https://www.oddenova.com/oddenova-og.png?v=c1189f30"');
     expect(html).toContain('<title>oddeNova | Vibe Your Live Music</title>');
   });
 
@@ -46,9 +48,9 @@ describe('renderShareHtml', () => {
 
     expect(html).toContain('<html lang="en">');
     expect(html).toContain('content="oddeNova | Vibe Your Live Music"');
-    expect(html).toContain('name="description"\n      content="Vibes in your head -&gt; Music in your ears"');
-    expect(html).toContain('property="og:description"\n      content="Vibes in your head -&gt; Music in your ears"');
-    expect(html).toContain('name="twitter:description"\n      content="Vibes in your head -&gt; Music in your ears"');
+    expect(html).toContain('name="description"\n      content="Plain text in, rich music out"');
+    expect(html).toContain('property="og:description"\n      content="Plain text in, rich music out"');
+    expect(html).toContain('name="twitter:description"\n      content="Plain text in, rich music out"');
     expect(html).toContain('property="og:url" content="https://oddenova.com/s/abc123"');
   });
 

--- a/src/services/share-page-meta.ts
+++ b/src/services/share-page-meta.ts
@@ -1,11 +1,11 @@
 import type { ShareLocale } from './share';
 
 const SHARE_TITLE = 'oddeNova | Vibe Your Live Music';
-const SHARE_IMAGE = 'https://oddenova.com/oddenova-og.png';
+const SHARE_IMAGE = 'https://www.oddenova.com/oddenova-og.png?v=c1189f30';
 
 const SHARE_DESCRIPTIONS: Record<ShareLocale, string> = {
   'zh-CN': '即兴 vibe 音乐，让灵感，自由发声',
-  en: 'Vibes in your head -> Music in your ears',
+  en: 'Plain text in, rich music out',
 };
 
 interface RenderShareHtmlOptions {
@@ -28,7 +28,11 @@ function escapeHtmlAttr(value: string): string {
 function replaceMeta(html: string, selector: string, value: string): string {
   const escaped = escapeHtmlAttr(value);
   const pattern = new RegExp(`(<meta\\b(?=[^>]*${selector})[^>]*\\bcontent=")[^"]*("[^>]*>)`, 'i');
-  return html.replace(pattern, `$1${escaped}$2`);
+  const replaced = html.replace(pattern, `$1${escaped}$2`);
+  if (replaced !== html) {
+    return replaced;
+  }
+  return html.replace(/<\/head>/i, `    <meta ${selector} content="${escaped}" />\n  </head>`);
 }
 
 export function renderShareHtml(html: string, options: RenderShareHtmlOptions): string {


### PR DESCRIPTION
Change share metadata: update the SHARE_IMAGE to the www host with a cache-busting ?v=c1189f30 query and revise the English description copy to "Plain text in, rich music out". Add a fallback in replaceMeta so missing meta tags are inserted before </head> instead of silently failing. Update index.html, service code and tests to reflect these changes (api/share-page.ts, src/services/share-page-meta.ts, index.html and related tests). These changes ensure the correct og/twitter image URL is used with versioning and make meta replacement more robust.