### PR TITLE
Prefer native share on coarse-pointer devices

### DIFF
--- a/src/services/__tests__/share-target.test.ts
+++ b/src/services/__tests__/share-target.test.ts
@@ -6,10 +6,24 @@ describe('shareUrl', () => {
     vi.restoreAllMocks();
   });
 
-  it('copies with Clipboard API without opening native share', async () => {
+  function stubCoarsePointer(matches: boolean) {
+    vi.stubGlobal('matchMedia', vi.fn((query: string) => ({
+      matches: query === '(pointer: coarse)' ? matches : false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })));
+  }
+
+  it('copies with Clipboard API before opening native share on desktop', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     const nativeShare = vi.fn().mockResolvedValue(undefined);
 
+    stubCoarsePointer(false);
     vi.stubGlobal('navigator', {
       clipboard: { writeText },
       share: nativeShare,
@@ -18,6 +32,32 @@ describe('shareUrl', () => {
     await expect(shareUrl('https://www.oddenova.com/s/abc123')).resolves.toBe('copied');
     expect(writeText).toHaveBeenCalledWith('https://www.oddenova.com/s/abc123');
     expect(nativeShare).not.toHaveBeenCalled();
+  });
+
+  it('opens native share before falling back to Clipboard API on mobile', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const nativeShare = vi.fn().mockResolvedValue(undefined);
+
+    stubCoarsePointer(true);
+    vi.stubGlobal('navigator', {
+      clipboard: { writeText },
+      share: nativeShare,
+    });
+
+    await expect(shareUrl('https://www.oddenova.com/s/abc123')).resolves.toBe('shared');
+    expect(nativeShare).toHaveBeenCalledWith({ url: 'https://www.oddenova.com/s/abc123' });
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it('falls back to Clipboard API when native share is unavailable', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+
+    vi.stubGlobal('navigator', {
+      clipboard: { writeText },
+    });
+
+    await expect(shareUrl('https://www.oddenova.com/s/abc123')).resolves.toBe('copied');
+    expect(writeText).toHaveBeenCalledWith('https://www.oddenova.com/s/abc123');
   });
 
   it('falls back to legacy copy when Clipboard API is unavailable', async () => {
@@ -48,9 +88,9 @@ describe('shareUrl', () => {
     expect(removed).toEqual([textarea]);
   });
 
-  it('falls back to native share when clipboard copy is unavailable', async () => {
-    const writeText = vi.fn().mockRejectedValue(new Error('NotAllowedError'));
-    const nativeShare = vi.fn().mockResolvedValue(undefined);
+  it('falls back to Clipboard API when native share is rejected', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const nativeShare = vi.fn().mockRejectedValue(new DOMException('NotAllowedError', 'NotAllowedError'));
 
     vi.stubGlobal('navigator', {
       clipboard: { writeText },
@@ -70,9 +110,9 @@ describe('shareUrl', () => {
       },
     });
 
-    await expect(shareUrl('https://www.oddenova.com/s/abc123')).resolves.toBe('shared');
-    expect(writeText).toHaveBeenCalledWith('https://www.oddenova.com/s/abc123');
+    await expect(shareUrl('https://www.oddenova.com/s/abc123')).resolves.toBe('copied');
     expect(nativeShare).toHaveBeenCalledWith({ url: 'https://www.oddenova.com/s/abc123' });
+    expect(writeText).toHaveBeenCalledWith('https://www.oddenova.com/s/abc123');
   });
 
   it('shows the share URL when automatic share targets are unavailable', async () => {

--- a/src/services/share-target.ts
+++ b/src/services/share-target.ts
@@ -20,8 +20,34 @@ function legacyCopy(text: string): boolean {
   }
 }
 
+function prefersNativeShare(): boolean {
+  return typeof globalThis.matchMedia === 'function' && globalThis.matchMedia('(pointer: coarse)').matches;
+}
+
+async function nativeShare(url: string): Promise<boolean> {
+  const nav = globalThis.navigator;
+  if (!nav?.share) return false;
+  try {
+    await nav.share({ url });
+    return true;
+  } catch {
+    // Fall through to copy/prompt fallbacks when native sharing is unavailable
+    // for the current browser context.
+    return false;
+  }
+}
+
 export async function shareUrl(url: string): Promise<ShareTargetResult> {
   const nav = globalThis.navigator;
+  const shouldPreferNativeShare = prefersNativeShare();
+  let triedNativeShare = false;
+
+  if (shouldPreferNativeShare) {
+    triedNativeShare = true;
+    if (await nativeShare(url)) {
+      return 'shared';
+    }
+  }
 
   if (nav?.clipboard?.writeText) {
     try {
@@ -34,8 +60,7 @@ export async function shareUrl(url: string): Promise<ShareTargetResult> {
 
   if (legacyCopy(url)) return 'copied';
 
-  if (nav?.share) {
-    await nav.share({ url });
+  if (!triedNativeShare && await nativeShare(url)) {
     return 'shared';
   }
 


### PR DESCRIPTION
Add logic to prefer the Web Share API on devices with a coarse pointer and consolidate native share handling.

- Introduce prefersNativeShare() and nativeShare() helpers to detect coarse-pointer devices (matchMedia) and attempt navigator.share with proper error handling.
- Update shareUrl() to try native share first on coarse-pointer devices, avoid double-invoking native share, and fall back to clipboard or legacy copy when sharing is unavailable or rejected.
- Update tests: add stubCoarsePointer helper and new test cases for desktop vs mobile ordering, native-share-unavailable fallback, and native-share rejection falling back to clipboard; adjust existing expectations accordingly.

These changes improve UX by favoring the native share sheet on mobile and make shareUrl() behavior more predictable and resilient to errors.