### PR TITLE
Show edit icon on session title

### DIFF
--- a/src/components/EditableSessionTitle.tsx
+++ b/src/components/EditableSessionTitle.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { t } from '../lib/i18n';
+import { EditIcon } from './icons';
 
 interface EditableSessionTitleProps {
   title: string;
@@ -88,7 +89,7 @@ export default function EditableSessionTitle({
     <button
       type="button"
       data-session-title-edit
-      className={className}
+      className={`group flex items-center gap-1.5 ${className}`}
       title={displayTitle}
       onClick={(e) => {
         e.stopPropagation();
@@ -98,6 +99,10 @@ export default function EditableSessionTitle({
       }}
     >
       <span className={titleTextClassName}>{displayTitle}</span>
+      <EditIcon
+        size={12}
+        className="shrink-0 text-text-muted opacity-0 group-hover:opacity-100 transition-opacity"
+      />
     </button>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -127,7 +127,7 @@ export default function Sidebar({
           title={title}
           canEdit={!!currentId && messages.length > 0}
           className="min-w-0 flex-1 text-left"
-          titleTextClassName="block text-base font-bold text-text-muted truncate"
+          titleTextClassName="block min-w-0 text-base font-bold text-text-muted truncate"
           inputClassName="min-w-0 flex-1 bg-transparent border border-border px-1 py-0.5 text-base font-bold text-text-primary outline-none focus:border-accent/60"
           onRename={(nextTitle) => {
             if (currentId) onRenameSession(currentId, nextTitle);


### PR DESCRIPTION
Import and render an EditIcon in EditableSessionTitle, adding group/flex classes to the edit button so the icon fades in on hover. Also add min-w-0 to the Sidebar titleTextClassName to ensure proper truncation and prevent layout overflow when titles are long.