### PR TITLE
Normalize MIDI-standard GM names to strudel canonical names

### DIFF
--- a/src/agent/__tests__/tools.test.ts
+++ b/src/agent/__tests__/tools.test.ts
@@ -121,4 +121,14 @@ stack(
     const result = await setCode({ code: '   \n  ' }, ctx);
     expect(result.ok).toBe(false);
   });
+
+  it('把 MIDI 标准 GM 名归一化为 strudel 规范名', async () => {
+    const ctx = makeCtx('');
+    const result = await setCode(
+      { code: 'note("c4 e4 g4").s("gm_acoustic_grand_piano")' },
+      ctx,
+    );
+    expect(result.ok).toBe(true);
+    expect(ctx.state.code).toBe('note("c4 e4 g4").s("gm_piano")');
+  });
 });

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -5,6 +5,7 @@
 
 import { parseScore } from './parser';
 import { validateCodeRuntime, validateCodeTranspiler, normalizeCode } from '../services/strudel';
+import { normalizeGmSampleNames } from '../lib/sample-allowlist';
 
 export interface AgentState {
   code: string;
@@ -106,7 +107,10 @@ export const TOOLS: ToolDef[] = [
       if (typeof args.code !== 'string' || !args.code.trim()) {
         return { ok: false, error: (ctx.isZh ?? true) ? 'code 不能为空' : 'code must not be empty' };
       }
-      const code = args.code.trim();
+      // Rewrite MIDI-standard GM names (e.g. gm_acoustic_grand_piano) to strudel's
+      // canonical names (gm_piano) so the stored/validated/committed code stays
+      // portable to vanilla strudel — oddeNova's runtime aliases are only a fallback.
+      const code = normalizeGmSampleNames(args.code.trim());
       const score = parseScore(code);
       ctx.state.code = code;
       return {

--- a/src/lib/__tests__/sample-allowlist.test.ts
+++ b/src/lib/__tests__/sample-allowlist.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { findUnknownSamples } from '../sample-allowlist';
+import { findUnknownSamples, normalizeGmSampleNames } from '../sample-allowlist';
 
 describe('findUnknownSamples', () => {
   it('合法 sample 不报错', () => {
@@ -58,5 +58,26 @@ describe('findUnknownSamples', () => {
   it('逗号分隔的多轨 mini-notation 不误报', () => {
     // s("bd*4, ~ sd ~ sd, hh*8") — commas are multi-track separators, not part of sample names
     expect(findUnknownSamples('s("bd*4, ~ sd ~ sd, hh*8")')).toEqual([]);
+  });
+});
+
+describe('normalizeGmSampleNames', () => {
+  it('把 MIDI 标准名改写为 strudel 规范名', () => {
+    expect(normalizeGmSampleNames('s("gm_acoustic_grand_piano")')).toBe('s("gm_piano")');
+    expect(normalizeGmSampleNames('note("c4").s("gm_pad_2_warm")')).toBe('note("c4").s("gm_pad_warm")');
+    expect(normalizeGmSampleNames('s("gm_lead_square")')).toBe('s("gm_lead_1_square")');
+  });
+
+  it('honky_tonk_piano 优先于 honky_tonk（最长匹配）', () => {
+    expect(normalizeGmSampleNames('s("gm_honky_tonk_piano")')).toBe('s("gm_piano")');
+    expect(normalizeGmSampleNames('s("gm_honky_tonk")')).toBe('s("gm_piano")');
+  });
+
+  it('已是规范名时保持不变', () => {
+    expect(normalizeGmSampleNames('s("gm_piano gm_epiano1")')).toBe('s("gm_piano gm_epiano1")');
+  });
+
+  it('改写后的代码通过 sample 校验', () => {
+    expect(findUnknownSamples(normalizeGmSampleNames('s("gm_acoustic_grand_piano")'))).toEqual([]);
   });
 });

--- a/src/lib/sample-allowlist.ts
+++ b/src/lib/sample-allowlist.ts
@@ -48,6 +48,46 @@ export const MELODIC_SAMPLES: readonly string[] = [
   'piano', 'arpy', 'bass', 'moog', 'juno', 'sax', 'gtr', 'pluck', 'sitar', 'stab',
 ];
 
+// MIDI-standard GM name → strudel canonical name.
+// The LLM tends to generate the long MIDI-standard names from its training data,
+// but strudel (and strudel.cc) only know the shorter canonical names. This map is
+// the single source of truth used in three places:
+//   1. soundfont-loader.ts — registers the aliases at runtime (playback fallback).
+//   2. SAMPLE_ALLOWLIST below — so validate() accepts the alias spelling. These
+//      names are deliberately kept OUT of GM_INSTRUMENTS so the system prompt
+//      (which lists GM_INSTRUMENTS) steers the model toward the canonical names.
+//   3. normalizeGmSampleNames() — rewrites aliases to canonical names so the
+//      committed code is portable to vanilla strudel, not just oddeNova.
+export const GM_NAME_ALIASES: Readonly<Record<string, string>> = {
+  // Piano
+  gm_acoustic_grand_piano: 'gm_piano',
+  gm_bright_acoustic_piano: 'gm_piano',
+  gm_electric_grand_piano: 'gm_piano',
+  gm_honky_tonk_piano: 'gm_piano',
+  gm_honky_tonk: 'gm_piano',
+  // Electric pianos
+  gm_electric_piano_1: 'gm_epiano1',
+  gm_electric_piano_2: 'gm_epiano2',
+  // Pads (MIDI uses numbered names; strudel drops the number)
+  gm_pad_1_new_age: 'gm_pad_new_age',
+  gm_pad_2_warm: 'gm_pad_warm',
+  gm_pad_3_polysynth: 'gm_pad_poly',
+  gm_pad_4_choir: 'gm_pad_choir',
+  gm_pad_5_bowed: 'gm_pad_bowed',
+  gm_pad_6_metallic: 'gm_pad_metallic',
+  gm_pad_7_halo: 'gm_pad_halo',
+  gm_pad_8_sweep: 'gm_pad_sweep',
+  // Leads (MIDI uses numbered names)
+  gm_lead_square: 'gm_lead_1_square',
+  gm_lead_sawtooth: 'gm_lead_2_sawtooth',
+  gm_lead_calliope: 'gm_lead_3_calliope',
+  gm_lead_chiff: 'gm_lead_4_chiff',
+  gm_lead_charang: 'gm_lead_5_charang',
+  gm_lead_voice: 'gm_lead_6_voice',
+  gm_lead_fifths: 'gm_lead_7_fifths',
+  gm_lead_bass_lead: 'gm_lead_8_bass_lead',
+};
+
 // General MIDI soundfont instruments — exact names from strudel's gm.mjs.
 // Loaded via registerSoundfonts() in prebake (src/services/strudel.ts).
 // Use with note() or n().scale() + .s("gm_...").
@@ -103,15 +143,6 @@ export const GM_INSTRUMENTS: readonly string[] = [
   // Sound Effects
   'gm_guitar_fret_noise', 'gm_breath_noise', 'gm_seashore', 'gm_bird_tweet',
   'gm_telephone', 'gm_helicopter', 'gm_applause', 'gm_gunshot',
-  // MIDI-standard name aliases (strudel uses shorter names; these are accepted
-  // so validate() doesn't reject LLM-generated code that uses standard names)
-  'gm_acoustic_grand_piano', 'gm_bright_acoustic_piano', 'gm_electric_grand_piano',
-  'gm_honky_tonk_piano', 'gm_honky_tonk',
-  'gm_electric_piano_1', 'gm_electric_piano_2',
-  'gm_pad_1_new_age', 'gm_pad_2_warm', 'gm_pad_3_polysynth', 'gm_pad_4_choir',
-  'gm_pad_5_bowed', 'gm_pad_6_metallic', 'gm_pad_7_halo', 'gm_pad_8_sweep',
-  'gm_lead_square', 'gm_lead_sawtooth', 'gm_lead_calliope', 'gm_lead_chiff',
-  'gm_lead_charang', 'gm_lead_voice', 'gm_lead_fifths', 'gm_lead_bass_lead',
 ];
 
 // Drum machine packs from tidal-drum-machines.md.
@@ -393,6 +424,10 @@ export const SAMPLE_ALLOWLIST: Set<string> = new Set([
   ...MELODIC_SAMPLES,
   ...DRUM_MACHINE_SAMPLES,
   ...GM_INSTRUMENTS,
+  // MIDI-standard alias spellings — accepted so validate() doesn't reject
+  // LLM-generated code, but intentionally NOT in GM_INSTRUMENTS so the prompt
+  // doesn't advertise them. normalizeGmSampleNames() rewrites them to canonical.
+  ...Object.keys(GM_NAME_ALIASES),
   ...VCSL_SAMPLES,
   ...MRIDANGAM_SAMPLES,
   ..._dmAliasVariants,
@@ -415,6 +450,29 @@ const VALID_BANK_SUFFIXES: ReadonlySet<string> = new Set([
   'bd', 'sd', 'hh', 'oh', 'cp', 'cb', 'cr', 'lt', 'mt', 'ht', 'rd',
   'rim', 'sh', 'tb', 'perc', 'misc', 'fx',
 ]);
+
+// Whole-word matcher for the MIDI-standard alias names, longest first so that
+// e.g. `gm_honky_tonk_piano` is tried before `gm_honky_tonk`. The names are
+// unique `gm_*` identifiers that only ever appear inside s("...") sample
+// strings, so a global word-boundary replace is safe.
+const _gmAliasRe = new RegExp(
+  '\\b(' +
+    Object.keys(GM_NAME_ALIASES)
+      .sort((a, b) => b.length - a.length)
+      .join('|') +
+    ')\\b',
+  'g',
+);
+
+/**
+ * Rewrite MIDI-standard GM names (e.g. `gm_acoustic_grand_piano`) to strudel's
+ * canonical names (`gm_piano`). oddeNova registers the alias names at runtime so
+ * they play locally, but vanilla strudel / strudel.cc only know the canonical
+ * names — normalizing here keeps the committed code portable.
+ */
+export function normalizeGmSampleNames(code: string): string {
+  return code.replace(_gmAliasRe, (m) => GM_NAME_ALIASES[m] ?? m);
+}
 
 export function findUnknownSamples(code: string): string[] {
   const unknown: string[] = [];

--- a/src/lib/soundfont-loader.ts
+++ b/src/lib/soundfont-loader.ts
@@ -12,6 +12,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore — gm-fonts.js is a plain JS ESM file with no type declarations
 import gm from './gm-fonts.js';
+import { GM_NAME_ALIASES } from './sample-allowlist';
 import { noteToMidi, freqToMidi, getSoundIndex } from '@strudel/core';
 import {
   getAudioContext,
@@ -204,40 +205,12 @@ export function registerSoundfonts(): void {
   }
 
   // MIDI-standard name aliases → strudel canonical names.
-  // The LLM tends to generate these from training data; register them so
-  // they work at runtime (allowlist also includes them).
+  // The LLM tends to generate these from training data; register them so they
+  // play at runtime as a fallback. The committed code itself is normalized to
+  // the canonical names (see normalizeGmSampleNames) so it stays portable to
+  // vanilla strudel. GM_NAME_ALIASES is the single source of truth.
   const gmMap = gm as Record<string, string[]>;
-  const ALIASES: Record<string, string> = {
-    // Piano
-    gm_acoustic_grand_piano: 'gm_piano',
-    gm_bright_acoustic_piano: 'gm_piano',
-    gm_electric_grand_piano: 'gm_piano',
-    gm_honky_tonk_piano: 'gm_piano',
-    gm_honky_tonk: 'gm_piano',
-    // Electric pianos
-    gm_electric_piano_1: 'gm_epiano1',
-    gm_electric_piano_2: 'gm_epiano2',
-    // Pads (MIDI uses numbered names; strudel drops the number)
-    gm_pad_1_new_age: 'gm_pad_new_age',
-    gm_pad_2_warm: 'gm_pad_warm',
-    gm_pad_3_polysynth: 'gm_pad_poly',
-    gm_pad_4_choir: 'gm_pad_choir',
-    gm_pad_5_bowed: 'gm_pad_bowed',
-    gm_pad_6_metallic: 'gm_pad_metallic',
-    gm_pad_7_halo: 'gm_pad_halo',
-    gm_pad_8_sweep: 'gm_pad_sweep',
-    // Leads (MIDI uses numbered names)
-    gm_lead_square: 'gm_lead_1_square',
-    gm_lead_sawtooth: 'gm_lead_2_sawtooth',
-    gm_lead_calliope: 'gm_lead_3_calliope',
-    gm_lead_chiff: 'gm_lead_4_chiff',
-    gm_lead_charang: 'gm_lead_5_charang',
-    gm_lead_voice: 'gm_lead_6_voice',
-    gm_lead_fifths: 'gm_lead_7_fifths',
-    gm_lead_bass_lead: 'gm_lead_8_bass_lead',
-  };
-
-  for (const [alias, canonical] of Object.entries(ALIASES)) {
+  for (const [alias, canonical] of Object.entries(GM_NAME_ALIASES)) {
     const fonts = gmMap[canonical];
     if (!fonts) continue;
     registerSound(alias, createGMSoundHandler(fonts), { type: 'soundfont', prebake: true, fonts });


### PR DESCRIPTION
The LLM tends to generate long MIDI-standard soundfont names (e.g. gm_acoustic_grand_piano) from its training data. These played in oddeNova via runtime aliases but were silent in vanilla strudel/strudel.cc, which only know the canonical short names (gm_piano).

- Add GM_NAME_ALIASES as the single source of truth and normalizeGmSampleNames()
- Rewrite aliases to canonical names in setCode so the stored/validated/committed code stays portable to vanilla strudel
- Keep GM_INSTRUMENTS canonical-only so the system prompt steers the model toward canonical names; aliases live only in SAMPLE_ALLOWLIST as a validation fallback
- Source soundfont-loader runtime aliases from the shared map to avoid drift