### PR TITLE
Add 808/909 dirt-sample folders to the allowlist

### DIFF
--- a/src/lib/__tests__/sample-allowlist.test.ts
+++ b/src/lib/__tests__/sample-allowlist.test.ts
@@ -11,6 +11,10 @@ describe('findUnknownSamples', () => {
     expect(result).toEqual(['superpad', 'violin']);
   });
 
+  it('808/909 鼓机文件夹名合法', () => {
+    expect(findUnknownSamples('s("808 909")')).toEqual([]);
+  });
+
   it('GM soundfont 名合法', () => {
     expect(findUnknownSamples('s("gm_acoustic_grand_piano")')).toEqual([]);
   });

--- a/src/lib/sample-allowlist.ts
+++ b/src/lib/sample-allowlist.ts
@@ -8,6 +8,7 @@
 // Plus melodic samples listed in the agent system prompt.
 
 export const DIRT_SAMPLES: readonly string[] = [
+  '808', '909',
   '808bd', '808cy', '808hc', '808ht', '808lc', '808lt', '808mc', '808mt', '808oh', '808sd',
   'ab', 'ade', 'ades2', 'ades3', 'ades4', 'alex', 'alphabet', 'amencutup', 'armora', 'arp', 'arpy',
   'auto', 'baa', 'baa2', 'bass', 'bass0', 'bass1', 'bass2', 'bass3', 'bassdm', 'bassfoo', 'battles',


### PR DESCRIPTION
The bare 808 and 909 drum-machine folders exist in upstream tidalcycles/dirt-samples (public/sample-index/dirt-samples.json) and play fine via s("808") / s("909"), but were missing from DIRT_SAMPLES, so the validator wrongly flagged them as unknown samples.