### PR TITLE
feat(NOVA-140): show per-turn code diff in conversation view

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -12,6 +12,10 @@ _Avoid_: request、run、call、generation
 一条独立的对话线,持有自己的消息列表、最后一次成功的代码、标题与时间戳;持久化在 IndexedDB,不可用时降级到内存。当前激活的那条叫 current session,其余在后台完成的 Agent turn 只落库、不动编辑器、不发声。
 _Avoid_: conversation、chat、thread
 
+**Session revision**:
+一次已 commit 的 [Agent turn] 所形成的不可变代码边界:记录该 turn 开始时的代码与最终代码,并由对应 assistant 消息引用。它描述的是"这一轮 agent 改了什么",不从相邻消息推算;播放失败仍会形成 revision 并记录失败状态,因为 [Playback commit] 仍以最新代码为 [Session] 真相。
+_Avoid_: diff(仅指展示结果)、snapshot、version
+
 **Score**:
 一段 Strudel 代码解析后的结构化表示:BPM、是否有 stack、各 [Layer] 的位置与内容。由 parser 这个深模块从原始代码字符串解析得到。
 _Avoid_: pattern、track、composition

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -427,7 +427,15 @@ export default function App() {
 
         {/* ── Conversation ── */}
         <div className="flex-1 min-h-0 overflow-hidden">
-          <ConversationView key={sessions.currentId ?? 'default'} messages={messages} isLoading={isLoading} onRollback={handleRollback} onBranch={sessions.branchFromMessage} onRetry={handleRetry} />
+          <ConversationView
+            key={sessions.currentId ?? 'default'}
+            messages={messages}
+            revisions={sessions.currentSession?.revisions}
+            isLoading={isLoading}
+            onRollback={handleRollback}
+            onBranch={sessions.branchFromMessage}
+            onRetry={handleRetry}
+          />
         </div>
 
         {/* ── Code Drawer ── */}
@@ -588,6 +596,7 @@ export default function App() {
         <Sidebar
           title={isVideoMode && videoTitle ? videoTitle : (isReplaying && !replayMessages.some((m) => m.role === 'user') ? t('newSessionTitle') : (current?.title ?? t('newSessionTitle')))}
           messages={videoDemoMsgs ?? messages}
+          revisions={current?.revisions}
           isLoading={isLoading || isReplaying}
           engineReady={strudel.engineReady}
           engineStatus={strudel.engineStatus}

--- a/src/agent/__tests__/parser.test.ts
+++ b/src/agent/__tests__/parser.test.ts
@@ -47,6 +47,14 @@ stack(
     expect(r.layers[0].source).toContain('note("c4")');
   });
 
+  it('@layer 名称允许连字符与非 ASCII 字符（模型实际会生成这类名字）', () => {
+    const code = `stack(\n  /* @layer OPEN-HAT点缀 */\n  s("~ ~ ~ oh"),\n  /* @layer lead synth */\n  note("c4")\n)`;
+    const r = parseScore(code);
+    expect(r.layers[0].name).toBe('OPEN-HAT点缀');
+    expect(r.layers[0].source).not.toContain('@layer');
+    expect(r.layers[1].name).toBe('lead synth');
+  });
+
   it('无标记时自动命名 layer_0 / layer_1', () => {
     const code = `stack(\n  s("bd"),\n  s("sd")\n)`;
     const r = parseScore(code);

--- a/src/agent/parser.ts
+++ b/src/agent/parser.ts
@@ -23,7 +23,9 @@ export interface ParsedScore {
   layers: ParsedLayer[];
 }
 
-const LAYER_MARKER_RE = /^\s*\/\*\s*@layer\s+([A-Za-z0-9_]+)\s*\*\//;
+// Layer names come from the model and are not charset-restricted (hyphens,
+// CJK, spaces all occur in practice) — accept anything up to the closing */.
+const LAYER_MARKER_RE = /^\s*\/\*\s*@layer\s+([^*]+?)\s*\*\//;
 
 // Matches a `.method("...<INNER>[/N]...")` call: captures the method name, the
 // angle-bracket INNER, and an optional trailing /N window. The window itself

--- a/src/components/CodeDiffView.tsx
+++ b/src/components/CodeDiffView.tsx
@@ -1,0 +1,148 @@
+import { useMemo, useState, type ReactNode } from 'react';
+import type { CodeRevision } from '../hooks/useSessions';
+import { buildCodeDiff, type DiffRow } from '../lib/code-diff';
+import { t } from '../lib/i18n';
+import { CheckIcon, ChevronRightIcon, CopyIcon } from './icons';
+
+interface CodeDiffViewProps {
+  messageId: string;
+  revision: CodeRevision;
+  expanded: boolean;
+  onToggle: () => void;
+}
+
+function counterpartFor(rows: DiffRow[], index: number): string | undefined {
+  const row = rows[index];
+  if (row.kind !== 'add' && row.kind !== 'remove') return undefined;
+  let start = index;
+  while (start > 0 && (rows[start - 1].kind === 'add' || rows[start - 1].kind === 'remove')) start--;
+  let end = index + 1;
+  while (end < rows.length && (rows[end].kind === 'add' || rows[end].kind === 'remove')) end++;
+  const block = rows.slice(start, end);
+  const sameKindBefore = block
+    .slice(0, index - start)
+    .filter((candidate) => candidate.kind === row.kind).length;
+  const otherKind = row.kind === 'add' ? 'remove' : 'add';
+  const counterpart = block.filter((candidate) => candidate.kind === otherKind)[sameKindBefore];
+  return counterpart && counterpart.kind !== 'skip' ? counterpart.text : undefined;
+}
+
+function highlightedText(text: string, counterpart: string | undefined, kind: 'add' | 'remove'): ReactNode {
+  if (counterpart == null) return text;
+  let prefix = 0;
+  while (prefix < text.length && prefix < counterpart.length && text[prefix] === counterpart[prefix]) prefix++;
+  let suffix = 0;
+  while (
+    suffix < text.length - prefix &&
+    suffix < counterpart.length - prefix &&
+    text[text.length - 1 - suffix] === counterpart[counterpart.length - 1 - suffix]
+  ) suffix++;
+  const changedEnd = suffix === 0 ? text.length : text.length - suffix;
+  const changed = text.slice(prefix, changedEnd);
+  if (!changed) return text;
+  return (
+    <>
+      {text.slice(0, prefix)}
+      <span className={kind === 'add' ? 'bg-emerald-300/20' : 'bg-rose-300/20'}>{changed}</span>
+      {text.slice(changedEnd)}
+    </>
+  );
+}
+
+export function CodeDiffView({ messageId, revision, expanded, onToggle }: CodeDiffViewProps) {
+  const [copied, setCopied] = useState(false);
+  const diff = useMemo(
+    () => buildCodeDiff(revision.beforeCode, revision.afterCode),
+    [revision.beforeCode, revision.afterCode],
+  );
+
+  return (
+    <div className="mt-4 -ml-1 overflow-hidden rounded-md border border-[#93C2FF]/30 bg-bg-primary/35 animate-fade-in">
+      <div className="flex w-full items-stretch bg-bg-primary/60 text-[11px] text-[#93C2FF]/70">
+        <button
+          type="button"
+          data-code-diff-toggle={messageId}
+          aria-expanded={expanded}
+          onClick={onToggle}
+          className="flex min-w-0 flex-1 items-center gap-1.5 px-2 py-1.5 text-left transition-colors hover:bg-bg-primary/80 hover:text-[#93C2FF]/90"
+        >
+          <ChevronRightIcon
+            size={12}
+            className={`shrink-0 transition-transform ${expanded ? 'rotate-90' : ''}`}
+          />
+          <span>{t('viewChanges')}</span>
+          <span className="text-emerald-300/75">+{diff.additions}</span>
+          <span className="text-rose-300/75">−{diff.deletions}</span>
+          {revision.playbackStatus === 'failed' && (
+            <span className="ml-1 truncate text-amber-300/70">{t('revisionPlaybackFailed')}</span>
+          )}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            navigator.clipboard.writeText(revision.afterCode).then(() => {
+              setCopied(true);
+              setTimeout(() => setCopied(false), 2000);
+            });
+          }}
+          className="px-2 py-1.5 transition-colors hover:bg-bg-primary/80 hover:text-[#93C2FF]/90"
+          title={t('copyCode')}
+        >
+          {copied ? <CheckIcon size={13} /> : <CopyIcon size={13} />}
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="border-t border-[#93C2FF]/15 bg-[#080a0d] py-1 animate-fade-in">
+          {diff.groups.length === 0 && (
+            <div className="px-3 py-3 text-[11px] text-text-muted">{t('noCodeChanges')}</div>
+          )}
+          {diff.groups.map((group) => (
+            <section key={group.key} data-diff-group={group.name} className="py-1.5 first:pt-0 last:pb-0">
+              <div className="sticky top-0 z-[1] flex items-center gap-2 border-y border-white/[0.055] bg-[#101319] px-2.5 py-1 font-mono text-[10px] tracking-[0.16em] text-white/55">
+                <span>{group.name.toUpperCase()}</span>
+                <span className="tracking-normal text-emerald-300/60">+{group.additions}</span>
+                <span className="tracking-normal text-rose-300/60">−{group.deletions}</span>
+              </div>
+              <div className="overflow-x-auto py-1 font-mono text-[11px] leading-[1.65]">
+                {group.rows.map((row, index) => {
+                  if (row.kind === 'skip') {
+                    return (
+                      <div key={`skip-${index}`} className="grid grid-cols-[2.25rem_2.25rem_1.25rem_minmax(max-content,1fr)] text-white/30">
+                        <span /><span /><span className="text-center">···</span>
+                        <span className="px-1.5 italic">{t('unchangedLines').replace('{count}', String(row.count))}</span>
+                      </div>
+                    );
+                  }
+                  const tone = row.kind === 'add'
+                    ? 'bg-emerald-400/[0.075] text-emerald-50/80'
+                    : row.kind === 'remove'
+                      ? 'bg-rose-400/[0.075] text-rose-50/75'
+                      : 'text-white/42';
+                  const sign = row.kind === 'add' ? '+' : row.kind === 'remove' ? '−' : ' ';
+                  const counterpart = counterpartFor(group.rows, index);
+                  return (
+                    <div
+                      key={`${row.kind}-${index}`}
+                      data-diff-kind={row.kind}
+                      className={`grid min-w-full grid-cols-[2.25rem_2.25rem_1.25rem_minmax(max-content,1fr)] ${tone}`}
+                    >
+                      <span className="select-none border-r border-white/[0.035] pr-1.5 text-right text-white/20">{row.oldLine ?? ''}</span>
+                      <span className="select-none border-r border-white/[0.035] pr-1.5 text-right text-white/20">{row.newLine ?? ''}</span>
+                      <span className="select-none text-center">{sign}</span>
+                      <code className="whitespace-pre pr-3">
+                        {row.kind === 'add' || row.kind === 'remove'
+                          ? highlightedText(row.text, counterpart, row.kind)
+                          : row.text}
+                      </code>
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/CodeDiffView.tsx
+++ b/src/components/CodeDiffView.tsx
@@ -105,6 +105,9 @@ export function CodeDiffView({ messageId, revision, expanded, onToggle }: CodeDi
                 <span className="tracking-normal text-rose-300/60">−{group.deletions}</span>
               </div>
               <div className="overflow-x-auto py-1 font-mono text-[11px] leading-[1.65]">
+                {/* w-max makes every row span the widest line, so row tints
+                    keep painting when the block is scrolled horizontally. */}
+                <div className="w-max min-w-full">
                 {group.rows.map((row, index) => {
                   if (row.kind === 'skip') {
                     return (
@@ -138,6 +141,7 @@ export function CodeDiffView({ messageId, revision, expanded, onToggle }: CodeDi
                     </div>
                   );
                 })}
+                </div>
               </div>
             </section>
           ))}

--- a/src/components/ConversationView.tsx
+++ b/src/components/ConversationView.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, type CSSProperties, type HTMLAttributes, type ReactNode } from 'react';
 import type { ChatMessage } from '../hooks/useChat';
+import type { CodeRevision } from '../hooks/useSessions';
 import { useIsMobile } from '../hooks/useIsMobile';
 import { Undo2 } from 'lucide-react';
 import { CheckIcon, ChevronRightIcon, CopyIcon, GitBranchIcon, RetryIcon } from './icons';
 import { ThinkingLottie } from './ThinkingLottie';
 import { t } from '../lib/i18n';
+import { CodeDiffView } from './CodeDiffView';
 
 type MobileNoSelectStyle = CSSProperties & {
   WebkitTouchCallout?: 'none';
@@ -56,6 +58,7 @@ function stripMarkdown(text: string): string {
 
 interface ConversationViewProps {
   messages: ChatMessage[];
+  revisions?: CodeRevision[];
   isLoading: boolean;
   isVideoMode?: boolean;
   scrollBottom?: boolean;
@@ -66,6 +69,7 @@ interface ConversationViewProps {
 
 export default function ConversationView({
   messages,
+  revisions,
   isLoading,
   isVideoMode = false,
   scrollBottom = false,
@@ -115,6 +119,10 @@ export default function ConversationView({
   const lastUserMsgId = useMemo(
     () => messages.findLast((m) => m.role === 'user')?.id,
     [messages],
+  );
+  const revisionsById = useMemo(
+    () => new Map((revisions ?? []).map((revision) => [revision.id, revision])),
+    [revisions],
   );
 
   // Detect manual user scroll: stop auto-following when more than 80px from
@@ -700,7 +708,15 @@ export default function ConversationView({
           >
             <div className="relative w-full rounded-xl px-2 py-2 text-sm bg-transparent text-text-primary">
               <p className="whitespace-pre-wrap break-words">{msg.content}</p>
-              {msg.code && (() => {
+              {msg.code && msg.revisionId && revisionsById.has(msg.revisionId) && (
+                <CodeDiffView
+                  messageId={msg.id}
+                  revision={revisionsById.get(msg.revisionId)!}
+                  expanded={expandedCode.has(msg.id)}
+                  onToggle={() => toggleCode(msg.id)}
+                />
+              )}
+              {msg.code && (!msg.revisionId || !revisionsById.has(msg.revisionId)) && (() => {
                 const isExpanded = expandedCode.has(msg.id);
                 const code = msg.code;
                 const lineCount = code.split('\n').length;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import type { ChatMessage } from '../hooks/useChat';
 import { t } from '../lib/i18n';
-import type { Session, TokenStats } from '../hooks/useSessions';
+import type { CodeRevision, Session, TokenStats } from '../hooks/useSessions';
 import { PlusIcon, HistoryIcon, PlayIcon } from './icons';
 import ConversationView from './ConversationView';
 import ChatInput from './ChatInput';
@@ -12,6 +12,7 @@ import EditableSessionTitle from './EditableSessionTitle';
 interface SidebarProps {
   title: string;
   messages: ChatMessage[];
+  revisions?: CodeRevision[];
   isLoading: boolean;
   engineReady: boolean;
   engineStatus?: 'initializing' | 'ready' | 'failed';
@@ -45,6 +46,7 @@ interface SidebarProps {
 export default function Sidebar({
   title,
   messages,
+  revisions,
   isLoading,
   engineReady,
   engineStatus = engineReady ? 'ready' : 'initializing',
@@ -171,6 +173,7 @@ export default function Sidebar({
         <ConversationView
           key={currentId ?? 'default'}
           messages={messages}
+          revisions={revisions}
           isLoading={isLoading && !isReplaying}
           isVideoMode={isVideoMode}
           scrollBottom={scrollBottom}

--- a/src/components/__tests__/ConversationView.test.tsx
+++ b/src/components/__tests__/ConversationView.test.tsx
@@ -4,6 +4,7 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ChatMessage } from '../../hooks/useChat';
+import type { CodeRevision } from '../../hooks/useSessions';
 import ConversationView from '../ConversationView';
 
 Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
@@ -33,7 +34,11 @@ function setMobileViewport(matches: boolean) {
   });
 }
 
-function renderConversationView(messages: ChatMessage[], onRollback = vi.fn()) {
+function renderConversationView(
+  messages: ChatMessage[],
+  onRollback = vi.fn(),
+  revisions?: CodeRevision[],
+) {
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
@@ -42,6 +47,7 @@ function renderConversationView(messages: ChatMessage[], onRollback = vi.fn()) {
     root.render(
       <ConversationView
         messages={messages}
+        revisions={revisions}
         isLoading={false}
         onRollback={onRollback}
         onBranch={vi.fn()}
@@ -52,6 +58,92 @@ function renderConversationView(messages: ChatMessage[], onRollback = vi.fn()) {
 
   return { container, root };
 }
+
+describe('ConversationView code revisions', () => {
+  const roots: Root[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) {
+      act(() => root.unmount());
+    }
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('shows compact stats and expands a Layer-grouped unified diff', () => {
+    setMobileViewport(false);
+    const messages: ChatMessage[] = [{
+      id: 'assistant-1',
+      role: 'assistant',
+      content: '完成',
+      code: 'stack(\n/* @layer drums */\ns("bd*2")\n)',
+      revisionId: 'rev-1',
+      timestamp: 1,
+    }];
+    const revisions: CodeRevision[] = [{
+      id: 'rev-1',
+      beforeCode: 'stack(\n/* @layer drums */\ns("bd")\n)',
+      afterCode: 'stack(\n/* @layer drums */\ns("bd*2")\n)',
+      playbackStatus: 'played',
+      createdAt: 1,
+    }];
+    const { container, root } = renderConversationView(messages, vi.fn(), revisions);
+    roots.push(root);
+
+    const button = container.querySelector<HTMLButtonElement>('[data-code-diff-toggle="assistant-1"]');
+    expect(button?.textContent).toContain('View changes');
+    expect(button?.textContent).toContain('+1');
+    expect(button?.textContent).toContain('−1');
+    expect(button?.getAttribute('aria-expanded')).toBe('false');
+    expect(container.textContent).not.toContain('DRUMS');
+
+    act(() => button?.click());
+
+    expect(button?.getAttribute('aria-expanded')).toBe('true');
+    expect(container.textContent).toContain('DRUMS');
+    expect(container.querySelector('[data-diff-kind="remove"]')?.textContent).toContain('s("bd")');
+    expect(container.querySelector('[data-diff-kind="add"]')?.textContent).toContain('s("bd*2")');
+  });
+
+  it('marks a persisted revision whose playback failed', () => {
+    setMobileViewport(false);
+    const messages: ChatMessage[] = [{
+      id: 'assistant-1',
+      role: 'assistant',
+      content: '无法播放',
+      code: 's("sd")',
+      revisionId: 'rev-1',
+      timestamp: 1,
+    }];
+    const revisions: CodeRevision[] = [{
+      id: 'rev-1',
+      beforeCode: 's("bd")',
+      afterCode: 's("sd")',
+      playbackStatus: 'failed',
+      createdAt: 1,
+    }];
+    const { container, root } = renderConversationView(messages, vi.fn(), revisions);
+    roots.push(root);
+
+    expect(container.textContent).toContain('Code updated · playback failed');
+  });
+
+  it('keeps the full-code viewer for legacy assistant messages', () => {
+    setMobileViewport(false);
+    const messages: ChatMessage[] = [{
+      id: 'assistant-legacy',
+      role: 'assistant',
+      content: '旧回复',
+      code: 's("bd")',
+      timestamp: 1,
+    }];
+    const { container, root } = renderConversationView(messages);
+    roots.push(root);
+
+    expect(container.textContent).toContain('Strudel code');
+    expect(container.textContent).not.toContain('View changes');
+  });
+});
 
 describe('ConversationView mobile interactions', () => {
   const roots: Root[] = [];

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -3,7 +3,7 @@
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { Session } from '../../hooks/useSessions';
+import type { CodeRevision, Session } from '../../hooks/useSessions';
 import Sidebar from '../Sidebar';
 
 Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
@@ -55,6 +55,44 @@ function renderSidebar(props: Partial<React.ComponentProps<typeof Sidebar>> = {}
 
   return { container, root };
 }
+
+describe('Sidebar code revisions', () => {
+  const roots: Root[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) {
+      act(() => root.unmount());
+    }
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  it('forwards revisions so assistant messages render the diff toggle', () => {
+    const messages: Session['messages'] = [
+      { id: 'm-1', role: 'user', content: '改鼓点', timestamp: 1 },
+      {
+        id: 'm-2',
+        role: 'assistant',
+        content: '完成',
+        code: 's("bd*2")',
+        revisionId: 'rev-1',
+        timestamp: 2,
+      },
+    ];
+    const revisions: CodeRevision[] = [{
+      id: 'rev-1',
+      beforeCode: 's("bd")',
+      afterCode: 's("bd*2")',
+      playbackStatus: 'played',
+      createdAt: 2,
+    }];
+    const { container, root } = renderSidebar({ messages, revisions });
+    roots.push(root);
+
+    const toggle = container.querySelector('[data-code-diff-toggle="m-2"]');
+    expect(toggle).not.toBeNull();
+  });
+});
 
 describe('Sidebar session title editing layout', () => {
   const roots: Root[] = [];

--- a/src/hooks/__tests__/useAgentRunner.test.ts
+++ b/src/hooks/__tests__/useAgentRunner.test.ts
@@ -90,7 +90,11 @@ describe('runAgentTurn', () => {
     await runAgentTurn(makeInput(), deps);
     expect(deps.play).toHaveBeenCalledWith('note("c3")');
     expect(deps.setCurrentCode).toHaveBeenCalledWith('note("c3")', 'S1');
-    expect(deps.addAssistantMessage).toHaveBeenCalledWith('done', 'note("c3")', 'S1');
+    expect(deps.addAssistantMessage).toHaveBeenCalledWith('done', 'note("c3")', 'S1', {
+      beforeCode: 'CURRENT',
+      afterCode: 'note("c3")',
+      playbackStatus: 'played',
+    });
   });
 
   it('persists the code even when playback fails — latest code is always the session truth', async () => {
@@ -102,6 +106,11 @@ describe('runAgentTurn', () => {
     const call = (deps.addAssistantMessage as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(call[1]).toBe('note("c3")');
     expect(String(call[0])).toContain('bad node');
+    expect(call[3]).toEqual({
+      beforeCode: 'CURRENT',
+      afterCode: 'note("c3")',
+      playbackStatus: 'failed',
+    });
   });
 
   it('on a background (non-current) session, persists without playing', async () => {
@@ -109,6 +118,19 @@ describe('runAgentTurn', () => {
     await runAgentTurn(makeInput(), deps);
     expect(deps.play).not.toHaveBeenCalled();
     expect(deps.setCurrentCode).toHaveBeenCalledWith('note("c3")', 'S1');
+    expect(deps.addAssistantMessage).toHaveBeenCalledWith('done', 'note("c3")', 'S1', {
+      beforeCode: 'CURRENT',
+      afterCode: 'note("c3")',
+      playbackStatus: 'not_attempted',
+    });
+  });
+
+  it('does not create a revision when code was not committed', async () => {
+    const deps = makeDeps({ runAgent: vi.fn(async () => makeResult({ committed: false })) });
+
+    await runAgentTurn(makeInput(), deps);
+
+    expect(deps.addAssistantMessage).toHaveBeenCalledWith('done', 'note("c3")', 'S1');
   });
 
   it('surfaces next-step suggestions parsed from the explanation', async () => {
@@ -117,7 +139,11 @@ describe('runAgentTurn', () => {
     await runAgentTurn(makeInput(), deps);
     expect(deps.setCommitSuggestions).toHaveBeenCalledWith(['加鼓', '提速']);
     // the next-steps block is stripped from the chat message
-    expect(deps.addAssistantMessage).toHaveBeenCalledWith('搞定', 'note("c3")', 'S1');
+    expect(deps.addAssistantMessage).toHaveBeenCalledWith('搞定', 'note("c3")', 'S1', {
+      beforeCode: 'CURRENT',
+      afterCode: 'note("c3")',
+      playbackStatus: 'played',
+    });
   });
 
   it('posts the explanation only when the result carries no code', async () => {
@@ -190,6 +216,11 @@ describe('runAgentTurn', () => {
     const deps = makeDeps({ runAgent, getCurrentCode: () => 'CURRENT' });
     await runAgentTurn(makeInput({ initialCode: 'OVERRIDE' }), deps);
     expect(runAgent.mock.calls[0][1]).toBe('OVERRIDE');
+    expect(deps.addAssistantMessage).toHaveBeenCalledWith('done', 'note("c3")', 'S1', {
+      beforeCode: 'OVERRIDE',
+      afterCode: 'note("c3")',
+      playbackStatus: 'played',
+    });
   });
 
   it('forwards moodContext to runAgent', async () => {

--- a/src/hooks/__tests__/useSessions.test.ts
+++ b/src/hooks/__tests__/useSessions.test.ts
@@ -175,6 +175,40 @@ describe('useSessions', () => {
     });
     expect(storageMocks.putSession).toHaveBeenCalledTimes(1);
   });
+
+  it('atomically stores a code revision and links it from the assistant message', async () => {
+    const { root, getHook } = await renderUseSessions();
+    roots.push(root);
+
+    act(() => {
+      getHook().addAssistantMessage('完成', 's("sd")', getHook().currentId!, {
+        beforeCode: 's("bd")',
+        afterCode: 's("sd")',
+        playbackStatus: 'played',
+      });
+    });
+
+    const session = getHook().currentSession!;
+    expect(session.revisions).toHaveLength(1);
+    expect(session.revisions?.[0]).toMatchObject({
+      beforeCode: 's("bd")',
+      afterCode: 's("sd")',
+      playbackStatus: 'played',
+    });
+    expect(session.messages[0].revisionId).toBe(session.revisions?.[0].id);
+  });
+
+  it('keeps ordinary assistant messages revision-free', async () => {
+    const { root, getHook } = await renderUseSessions();
+    roots.push(root);
+
+    act(() => {
+      getHook().addAssistantMessage('没有代码', undefined, getHook().currentId!);
+    });
+
+    expect(getHook().currentSession?.revisions).toBeUndefined();
+    expect(getHook().currentSession?.messages[0].revisionId).toBeUndefined();
+  });
 });
 
 describe('applyTruncateAndEdit', () => {
@@ -283,5 +317,24 @@ describe('applyTruncate', () => {
     });
     const result = applyTruncate(s, 'msg-1');
     expect(result.title).toBe('原标题');
+  });
+
+  it('截断消息时移除不再被引用的 revisions', () => {
+    const s = makeSession({
+      messages: [
+        { id: 'msg-0', role: 'user', content: '第一条', timestamp: 0 },
+        { id: 'msg-1', role: 'assistant', content: '版本一', code: 's("bd")', revisionId: 'rev-1', timestamp: 1 },
+        { id: 'msg-2', role: 'user', content: '第二条', timestamp: 2 },
+        { id: 'msg-3', role: 'assistant', content: '版本二', code: 's("sd")', revisionId: 'rev-2', timestamp: 3 },
+      ],
+      revisions: [
+        { id: 'rev-1', beforeCode: '', afterCode: 's("bd")', playbackStatus: 'played', createdAt: 1 },
+        { id: 'rev-2', beforeCode: 's("bd")', afterCode: 's("sd")', playbackStatus: 'played', createdAt: 3 },
+      ],
+    });
+
+    const result = applyTruncate(s, 'msg-2');
+
+    expect(result.revisions?.map((revision) => revision.id)).toEqual(['rev-1']);
   });
 });

--- a/src/hooks/useAgentRunner.ts
+++ b/src/hooks/useAgentRunner.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
 import type { useStrudel } from './useStrudel';
-import type { useSessions, TokenStats } from './useSessions';
+import type { useSessions, CodeRevisionDraft, TokenStats } from './useSessions';
 import { runAgent } from '../services/llm';
 import type { ConversationTurn, ProgressEvent } from '../services/llm';
 import { conversationHistoryFromMessages } from '../lib/conversation-history';
@@ -57,7 +57,12 @@ export interface AgentTurnDeps {
   getCurrentCode: () => string;
   snapshotHistory: () => ConversationTurn[];
   addUserMessage: (text: string) => void;
-  addAssistantMessage: (text: string, code: string | undefined, sessionId: string) => void;
+  addAssistantMessage: (
+    text: string,
+    code: string | undefined,
+    sessionId: string,
+    revision?: CodeRevisionDraft,
+  ) => void;
   setCurrentCode: (code: string, sessionId: string) => void;
   updateTokenStats: (stats: TokenStats, sessionId: string) => void;
 
@@ -95,6 +100,10 @@ export async function runAgentTurn(input: AgentTurnInput, deps: AgentTurnDeps): 
   deps.resetSuggestions();
   deps.clearRollbackPrefill();
 
+  // The revision baseline is the editor state at turn start. Capture it once:
+  // reading live code after the async agent call would include later user edits.
+  const beforeCode = input.initialCode ?? deps.getCurrentCode();
+
   // Snapshot history BEFORE the user message is written, so the current turn is
   // not echoed back into its own history.
   const history: ConversationTurn[] | undefined = input.includeHistory
@@ -117,7 +126,7 @@ export async function runAgentTurn(input: AgentTurnInput, deps: AgentTurnDeps): 
     const onProgress = deps.makeProgressHandler(sessionId);
     const result = await deps.runAgent(
       input.text,
-      input.initialCode ?? deps.getCurrentCode(),
+      beforeCode,
       onProgress,
       input.moodContext,
       signal,
@@ -148,22 +157,41 @@ export async function runAgentTurn(input: AgentTurnInput, deps: AgentTurnDeps): 
       if (deps.isCurrentSession(sessionId)) {
         // Always persist the newest code as the session truth, run or not.
         const success = await commitPlayback(result.code, sessionId, deps);
+        const revision: CodeRevisionDraft | undefined = result.committed
+          ? {
+              beforeCode,
+              afterCode: result.code,
+              playbackStatus: success ? 'played' : 'failed',
+            }
+          : undefined;
         if (success) {
           const nextSteps = parseNextSteps(result.explanation);
           if (nextSteps.length > 0) deps.setCommitSuggestions(nextSteps);
-          deps.addAssistantMessage(stripNextSteps(result.explanation), result.code, sessionId);
+          if (revision) {
+            deps.addAssistantMessage(stripNextSteps(result.explanation), result.code, sessionId, revision);
+          } else {
+            deps.addAssistantMessage(stripNextSteps(result.explanation), result.code, sessionId);
+          }
         } else {
-          deps.addAssistantMessage(
-            zh
-              ? `agent 生成完了但代码无法运行: ${deps.getStrudelError() || '未知错误'}`
-              : `Agent generated code but it failed to run: ${deps.getStrudelError() || 'unknown error'}`,
-            result.code,
-            sessionId,
-          );
+          const content = zh
+            ? `agent 生成完了但代码无法运行: ${deps.getStrudelError() || '未知错误'}`
+            : `Agent generated code but it failed to run: ${deps.getStrudelError() || 'unknown error'}`;
+          if (revision) {
+            deps.addAssistantMessage(content, result.code, sessionId, revision);
+          } else {
+            deps.addAssistantMessage(content, result.code, sessionId);
+          }
         }
       } else {
         // Background session completed: persist only, don't touch the editor or play audio.
-        deps.addAssistantMessage(stripNextSteps(result.explanation), result.code, sessionId);
+        const revision: CodeRevisionDraft | undefined = result.committed
+          ? { beforeCode, afterCode: result.code, playbackStatus: 'not_attempted' }
+          : undefined;
+        if (revision) {
+          deps.addAssistantMessage(stripNextSteps(result.explanation), result.code, sessionId, revision);
+        } else {
+          deps.addAssistantMessage(stripNextSteps(result.explanation), result.code, sessionId);
+        }
         deps.setCurrentCode(result.code, sessionId);
       }
     } else {
@@ -231,7 +259,7 @@ export function useAgentRunner(cfg: UseAgentRunnerConfig): (input: AgentTurnInpu
         getCurrentCode: () => currentCode,
         snapshotHistory: () => conversationHistoryFromMessages(sessions.currentSession?.messages ?? []),
         addUserMessage: (text) => sessions.addUserMessage(text),
-        addAssistantMessage: (text, code, id) => sessions.addAssistantMessage(text, code, id),
+        addAssistantMessage: (text, code, id, revision) => sessions.addAssistantMessage(text, code, id, revision),
         setCurrentCode: (code, id) => sessions.setCurrentCode(code, id),
         updateTokenStats: (stats, id) => sessions.updateTokenStats(stats, id),
         beginLoading: (id) => {

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -12,6 +12,8 @@ export interface ChatMessage {
   role: ChatRole;
   content: string;
   code?: string;
+  /** Immutable code boundary produced by this assistant turn. */
+  revisionId?: string;
   timestamp: number;
   // For role === 'progress':
   progressKind?: ProgressKind;

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -14,11 +14,25 @@ export interface TokenStats {
   modelId: string;
 }
 
+export type PlaybackStatus = 'played' | 'failed' | 'not_attempted';
+
+export interface CodeRevision {
+  id: string;
+  beforeCode: string;
+  afterCode: string;
+  playbackStatus: PlaybackStatus;
+  createdAt: number;
+}
+
+export type CodeRevisionDraft = Omit<CodeRevision, 'id' | 'createdAt'>;
+
 export interface Session {
   id: string;
   title: string;
   messages: ChatMessage[];
   code: string;
+  /** Optional for backward compatibility with sessions saved before revisions existed. */
+  revisions?: CodeRevision[];
   tokenStats?: TokenStats;
   /**
    * Next-step suggestion chips, bound to the code they were generated for.
@@ -39,6 +53,16 @@ function newSessionId(): string {
 
 function newMessageId(): string {
   return `msg-${Date.now()}-${++messageId}`;
+}
+
+function newRevisionId(): string {
+  return `rev-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function revisionsReferencedBy(messages: ChatMessage[], revisions?: CodeRevision[]): CodeRevision[] | undefined {
+  if (!revisions) return undefined;
+  const referenced = new Set(messages.flatMap((message) => message.revisionId ? [message.revisionId] : []));
+  return revisions.filter((revision) => referenced.has(revision.id));
 }
 
 function deriveTitle(messages: ChatMessage[]): string {
@@ -76,13 +100,14 @@ export function applyTruncateAndEdit(s: Session, targetMessageId: string, newCon
   const messages = [...before, newMsg];
   const shouldDeriveTitle = !before.some((m) => m.role === 'user') && s.title === t('newSessionTitle');
   const title = shouldDeriveTitle ? deriveTitle(messages) : s.title;
-  return { ...s, messages, title };
+  return { ...s, messages, revisions: revisionsReferencedBy(messages, s.revisions), title };
 }
 
 export function applyTruncate(s: Session, targetMessageId: string): Session {
   const index = s.messages.findIndex((m) => m.id === targetMessageId);
   if (index === -1) return s;
-  return { ...s, messages: s.messages.slice(0, index) };
+  const messages = s.messages.slice(0, index);
+  return { ...s, messages, revisions: revisionsReferencedBy(messages, s.revisions) };
 }
 
 export function useSessions() {
@@ -186,21 +211,29 @@ export function useSessions() {
   );
 
   const addAssistantMessage = useCallback(
-    (content: string, code?: string, sessionId?: string): void => {
+    (content: string, code?: string, sessionId?: string, revisionDraft?: CodeRevisionDraft): void => {
       const apply = getApply(sessionId);
-      apply((s) => ({
-        ...s,
-        messages: [
-          ...s.messages,
-          {
-            id: newMessageId(),
-            role: 'assistant' as const,
-            content,
-            code,
-            timestamp: Date.now(),
-          },
-        ],
-      }));
+      apply((s) => {
+        const now = Date.now();
+        const revision: CodeRevision | undefined = revisionDraft
+          ? { ...revisionDraft, id: newRevisionId(), createdAt: now }
+          : undefined;
+        return {
+          ...s,
+          revisions: revision ? [...(s.revisions ?? []), revision] : s.revisions,
+          messages: [
+            ...s.messages,
+            {
+              id: newMessageId(),
+              role: 'assistant' as const,
+              content,
+              code,
+              revisionId: revision?.id,
+              timestamp: now,
+            },
+          ],
+        };
+      });
     },
     [getApply]
   );
@@ -371,6 +404,7 @@ export function useSessions() {
         title: `${session.title}${t('branchSuffix')}`,
         messages: sliced,
         code,
+        revisions: revisionsReferencedBy(sliced, session.revisions),
         createdAt: now,
         updatedAt: now,
       };

--- a/src/lib/__tests__/code-diff.test.ts
+++ b/src/lib/__tests__/code-diff.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { buildCodeDiff, type DiffRow } from '../code-diff';
+
+function textsOf(rows: DiffRow[], kind: 'add' | 'remove'): string[] {
+  return rows.flatMap((row) => row.kind === kind ? [row.text] : []);
+}
+
+const before = `setcps(0.5)
+stack(
+  /* @layer drums */
+  s("bd ~ sd ~")
+  .gain(0.8),
+  /* @layer bass */
+  note("c2 e2")
+)`;
+
+describe('buildCodeDiff', () => {
+  it('groups modified and added code by named Layer and omits unchanged Layers', () => {
+    const after = `setcps(0.5)
+stack(
+  /* @layer drums */
+  s("bd*2 ~ sd ~")
+  .gain(0.8),
+  /* @layer bass */
+  note("c2 e2"),
+  /* @layer pad */
+  note("<c4 eb4 g4>").s("sine")
+)`;
+
+    const diff = buildCodeDiff(before, after);
+
+    expect(diff.groups.map((group) => [group.name, group.status])).toEqual([
+      ['drums', 'modified'],
+      ['pad', 'added'],
+    ]);
+    expect(diff.groups.some((group) => group.name === 'bass')).toBe(false);
+    expect(diff.additions).toBe(2);
+    expect(diff.deletions).toBe(1);
+  });
+
+  it('shows removed Layers after the surviving Layer order', () => {
+    const after = `setcps(0.5)
+stack(
+  /* @layer drums */
+  s("bd ~ sd ~")
+  .gain(0.8)
+)`;
+
+    const diff = buildCodeDiff(before, after);
+
+    expect(diff.groups.map((group) => [group.name, group.status])).toEqual([
+      ['bass', 'removed'],
+    ]);
+  });
+
+  it('groups tempo and non-Layer scaffolding changes under SCORE', () => {
+    const after = before.replace('setcps(0.5)', 'setcps(0.625)');
+
+    const diff = buildCodeDiff(before, after);
+
+    expect(diff.groups).toHaveLength(1);
+    expect(diff.groups[0].name).toBe('SCORE');
+    expect(textsOf(diff.groups[0].rows, 'remove')).toContain('setcps(0.5)');
+    expect(textsOf(diff.groups[0].rows, 'add')).toContain('setcps(0.625)');
+  });
+
+  it('keeps Layer grouping when a Layer name contains hyphens or non-ASCII characters', () => {
+    const after = `setcps(0.5)
+stack(
+  /* @layer drums */
+  s("bd ~ sd ~")
+  .gain(0.8),
+  /* @layer OPEN-HAT点缀 */
+  s("~ ~ ~ oh"),
+  /* @layer bass */
+  note("c2 e2")
+)`;
+
+    const diff = buildCodeDiff(before, after);
+
+    expect(diff.groups.map((group) => [group.name, group.status])).toEqual([
+      ['OPEN-HAT点缀', 'added'],
+    ]);
+  });
+
+  it('falls back to one SCORE group when code has no stable Layer markers', () => {
+    const diff = buildCodeDiff('stack(\n  s("bd"),\n  s("sd")\n)', 'stack(\n  s("bd*2"),\n  s("sd")\n)');
+
+    expect(diff.groups.map((group) => group.name)).toEqual(['SCORE']);
+  });
+
+  it('keeps two context lines and collapses longer unchanged runs', () => {
+    const oldCode = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten', 'eleven', 'twelve'].join('\n');
+    const newCode = ['one', 'two', 'THREE', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'TEN', 'eleven', 'twelve'].join('\n');
+
+    const diff = buildCodeDiff(oldCode, newCode);
+    const rows = diff.groups[0].rows;
+
+    expect(rows.some((row) => row.kind === 'skip')).toBe(true);
+    expect(rows.every((row) => row.kind !== 'context' || row.text !== '')).toBe(true);
+  });
+
+  it('normalizes CRLF before diffing', () => {
+    const diff = buildCodeDiff('setcps(0.5)\r\ns("bd")', 'setcps(0.5)\ns("bd")');
+
+    expect(diff.additions).toBe(0);
+    expect(diff.deletions).toBe(0);
+    expect(diff.groups).toEqual([]);
+  });
+});

--- a/src/lib/code-diff.ts
+++ b/src/lib/code-diff.ts
@@ -1,0 +1,190 @@
+import { parseScore } from '../agent/parser';
+
+export type DiffRow =
+  | { kind: 'context' | 'add' | 'remove'; text: string; oldLine?: number; newLine?: number }
+  | { kind: 'skip'; count: number };
+
+export interface CodeDiffGroup {
+  key: string;
+  name: string;
+  status: 'added' | 'removed' | 'modified';
+  additions: number;
+  deletions: number;
+  rows: DiffRow[];
+}
+
+export interface CodeDiff {
+  additions: number;
+  deletions: number;
+  groups: CodeDiffGroup[];
+}
+
+interface CodeSection {
+  key: string;
+  name: string;
+  source: string;
+}
+
+const CONTEXT_LINES = 2;
+
+function normalizeSource(source: string): string {
+  return source.replace(/\r\n?/g, '\n').trim();
+}
+
+function splitLines(source: string): string[] {
+  const normalized = normalizeSource(source);
+  return normalized ? normalized.split('\n') : [];
+}
+
+function scoreScaffolding(code: string): string {
+  const normalized = code.replace(/\r\n?/g, '\n');
+  const score = parseScore(normalized);
+  if (!score.hasStack || score.layers.length === 0) return normalizeSource(normalized);
+  return normalizeSource(
+    `${normalized.slice(0, score.stackArgsStart)}\n  /* layers */\n${normalized.slice(score.stackArgsEnd)}`,
+  );
+}
+
+function codeSections(code: string): { stableLayers: boolean; score: CodeSection; layers: CodeSection[] } {
+  const normalized = code.replace(/\r\n?/g, '\n');
+  const parsed = parseScore(normalized);
+  const stableLayers = parsed.layers.length > 0 && parsed.layers.every((layer) => !/^layer_\d+$/.test(layer.name));
+  const occurrences = new Map<string, number>();
+  const layers = parsed.layers.map((layer) => {
+    const occurrence = occurrences.get(layer.name) ?? 0;
+    occurrences.set(layer.name, occurrence + 1);
+    return {
+      key: `${layer.name}#${occurrence}`,
+      name: layer.name,
+      source: normalizeSource(layer.source),
+    };
+  });
+  return {
+    stableLayers,
+    score: { key: 'SCORE', name: 'SCORE', source: scoreScaffolding(normalized) },
+    layers,
+  };
+}
+
+function lineDiff(before: string, after: string): DiffRow[] {
+  const oldLines = splitLines(before);
+  const newLines = splitLines(after);
+  const table = Array.from({ length: oldLines.length + 1 }, () =>
+    Array<number>(newLines.length + 1).fill(0),
+  );
+
+  for (let oldIndex = oldLines.length - 1; oldIndex >= 0; oldIndex--) {
+    for (let newIndex = newLines.length - 1; newIndex >= 0; newIndex--) {
+      table[oldIndex][newIndex] = oldLines[oldIndex] === newLines[newIndex]
+        ? table[oldIndex + 1][newIndex + 1] + 1
+        : Math.max(table[oldIndex + 1][newIndex], table[oldIndex][newIndex + 1]);
+    }
+  }
+
+  const rows: DiffRow[] = [];
+  let oldIndex = 0;
+  let newIndex = 0;
+  while (oldIndex < oldLines.length || newIndex < newLines.length) {
+    if (
+      oldIndex < oldLines.length &&
+      newIndex < newLines.length &&
+      oldLines[oldIndex] === newLines[newIndex]
+    ) {
+      rows.push({
+        kind: 'context',
+        text: oldLines[oldIndex],
+        oldLine: oldIndex + 1,
+        newLine: newIndex + 1,
+      });
+      oldIndex++;
+      newIndex++;
+    } else if (
+      oldIndex < oldLines.length &&
+      (newIndex >= newLines.length || table[oldIndex + 1][newIndex] >= table[oldIndex][newIndex + 1])
+    ) {
+      rows.push({ kind: 'remove', text: oldLines[oldIndex], oldLine: oldIndex + 1 });
+      oldIndex++;
+    } else {
+      rows.push({ kind: 'add', text: newLines[newIndex], newLine: newIndex + 1 });
+      newIndex++;
+    }
+  }
+  return rows;
+}
+
+function collapseContext(rows: DiffRow[]): DiffRow[] {
+  const result: DiffRow[] = [];
+  let index = 0;
+  while (index < rows.length) {
+    if (rows[index].kind !== 'context') {
+      result.push(rows[index]);
+      index++;
+      continue;
+    }
+    const start = index;
+    while (index < rows.length && rows[index].kind === 'context') index++;
+    const run = rows.slice(start, index);
+    const hasChangeBefore = start > 0;
+    const hasChangeAfter = index < rows.length;
+    const keepBefore = hasChangeBefore ? Math.min(CONTEXT_LINES, run.length) : 0;
+    const keepAfter = hasChangeAfter ? Math.min(CONTEXT_LINES, run.length - keepBefore) : 0;
+    const skipped = run.length - keepBefore - keepAfter;
+
+    if (keepBefore > 0) result.push(...run.slice(0, keepBefore));
+    if (skipped > 0) result.push({ kind: 'skip', count: skipped });
+    if (keepAfter > 0) result.push(...run.slice(run.length - keepAfter));
+  }
+  return result;
+}
+
+function diffGroup(before: CodeSection | undefined, after: CodeSection | undefined): CodeDiffGroup | null {
+  const beforeSource = before?.source ?? '';
+  const afterSource = after?.source ?? '';
+  if (beforeSource === afterSource) return null;
+  const allRows = lineDiff(beforeSource, afterSource);
+  const additions = allRows.filter((row) => row.kind === 'add').length;
+  const deletions = allRows.filter((row) => row.kind === 'remove').length;
+  return {
+    key: after?.key ?? before!.key,
+    name: after?.name ?? before!.name,
+    status: !before ? 'added' : !after ? 'removed' : 'modified',
+    additions,
+    deletions,
+    rows: collapseContext(allRows),
+  };
+}
+
+export function buildCodeDiff(beforeCode: string, afterCode: string): CodeDiff {
+  const before = codeSections(beforeCode);
+  const after = codeSections(afterCode);
+  const groups: CodeDiffGroup[] = [];
+
+  if (!before.stableLayers || !after.stableLayers) {
+    const group = diffGroup(
+      { key: 'SCORE', name: 'SCORE', source: normalizeSource(beforeCode) },
+      { key: 'SCORE', name: 'SCORE', source: normalizeSource(afterCode) },
+    );
+    if (group) groups.push(group);
+  } else {
+    const scoreGroup = diffGroup(before.score, after.score);
+    if (scoreGroup) groups.push(scoreGroup);
+
+    const beforeByKey = new Map(before.layers.map((layer) => [layer.key, layer]));
+    const afterKeys = new Set(after.layers.map((layer) => layer.key));
+    for (const layer of after.layers) {
+      const group = diffGroup(beforeByKey.get(layer.key), layer);
+      if (group) groups.push(group);
+    }
+    for (const layer of before.layers) {
+      if (afterKeys.has(layer.key)) continue;
+      const group = diffGroup(layer, undefined);
+      if (group) groups.push(group);
+    }
+  }
+
+  return {
+    additions: groups.reduce((sum, group) => sum + group.additions, 0),
+    deletions: groups.reduce((sum, group) => sum + group.deletions, 0),
+    groups,
+  };
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -94,6 +94,10 @@ const S: Record<string, readonly [string, string]> = {
   actionsTitle:  ['思考过程', 'Process'],
   rollbackHere:  ['回滚到此处', 'Roll back to here'],
   copyCode:      ['复制代码', 'Copy code'],
+  viewChanges:   ['查看修改', 'View changes'],
+  noCodeChanges: ['本轮代码没有变化', 'No code changes in this turn'],
+  revisionPlaybackFailed: ['代码已更新 · 播放失败', 'Code updated · playback failed'],
+  unchangedLines: ['{count} 行未变化', '{count} unchanged lines'],
 
   // HistoryPanel
   history:    ['历史对话', 'History'],


### PR DESCRIPTION
Each committed agent turn now records an immutable code revision (before/after + playback status) on the session, linked from the assistant message. The conversation view renders it as a collapsible unified diff grouped by @layer markers, with legacy full-code fallback for messages without a revision.

Also broaden the @layer marker regex to accept hyphens, CJK and spaces in layer names — restricted charset caused the diff to collapse into a single SCORE group (and made such layers unaddressable by the agent).