### PR TITLE
feat: add AI-generated daily entry suggestions

### DIFF
--- a/api/cleanup.test.ts
+++ b/api/cleanup.test.ts
@@ -55,12 +55,17 @@ describe('cleanup handler', () => {
           blobs: [
             { pathname: 'daily-suggestions/2026-06-19.json', url: 'https://blob/retained', uploadedAt: new Date() },
             { pathname: 'daily-suggestions/not-a-date.json', url: 'https://blob/malformed', uploadedAt: new Date() },
+            { pathname: 'daily-suggestions/locks/2026-07-19.lock', url: 'https://blob/recent-lock', uploadedAt: new Date('2026-07-18T03:00:00.000Z') },
+            { pathname: 'daily-suggestions/locks/not-a-date.lock', url: 'https://blob/malformed-lock', uploadedAt: new Date('2026-06-01T00:00:00.000Z') },
           ],
           cursor: 'daily-next',
         } as never;
       }
       return {
-        blobs: [{ pathname: 'daily-suggestions/2026-06-18.json', url: 'https://blob/expired', uploadedAt: new Date() }],
+        blobs: [
+          { pathname: 'daily-suggestions/2026-06-18.json', url: 'https://blob/expired', uploadedAt: new Date() },
+          { pathname: 'daily-suggestions/locks/2026-07-18.lock', url: 'https://blob/old-lock', uploadedAt: new Date('2026-07-17T03:59:59.000Z') },
+        ],
       } as never;
     });
     const res = makeRes();
@@ -72,10 +77,15 @@ describe('cleanup handler', () => {
     expect(list).toHaveBeenCalledWith({ prefix: 'daily-suggestions/', cursor: undefined, limit: 1000 });
     expect(list).toHaveBeenCalledWith({ prefix: 'daily-suggestions/', cursor: 'daily-next', limit: 1000 });
     expect(del).toHaveBeenCalledWith(['https://blob/old-share']);
-    expect(del).toHaveBeenCalledWith(['https://blob/expired']);
-    expect(del).not.toHaveBeenCalledWith(expect.arrayContaining(['https://blob/retained', 'https://blob/malformed']));
+    expect(del).toHaveBeenCalledWith(['https://blob/expired', 'https://blob/old-lock']);
+    expect(del).not.toHaveBeenCalledWith(expect.arrayContaining([
+      'https://blob/retained',
+      'https://blob/malformed',
+      'https://blob/recent-lock',
+      'https://blob/malformed-lock',
+    ]));
     expect(res.statusCode).toBe(200);
-    expect(res.body).toEqual({ deleted: 1, dailySuggestionsDeleted: 1, errors: [] });
+    expect(res.body).toEqual({ deleted: 1, dailySuggestionsDeleted: 2, errors: [] });
   });
 
   it('continues daily cleanup when share listing fails', async () => {

--- a/api/cleanup.test.ts
+++ b/api/cleanup.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { del, list } from '@vercel/blob';
+import handler from './cleanup';
+
+vi.mock('@vercel/blob', () => ({ del: vi.fn(), list: vi.fn() }));
+
+function makeRes() {
+  return {
+    statusCode: 0,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body: unknown) {
+      this.body = body;
+      return this;
+    },
+  };
+}
+
+const request = { headers: { authorization: 'Bearer cron-secret' } };
+
+describe('cleanup handler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime('2026-07-18T04:00:00.000Z');
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    process.env.CRON_SECRET = 'cron-secret';
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    vi.resetAllMocks();
+    delete process.env.CRON_SECRET;
+  });
+
+  it('paginates both jobs, keeps 30 Beijing dates, and ignores malformed daily paths', async () => {
+    vi.mocked(list).mockImplementation(async ({ prefix, cursor }) => {
+      if (prefix === 'shares/' && !cursor) {
+        return {
+          blobs: [{ pathname: 'shares/old', url: 'https://blob/old-share', uploadedAt: new Date('2026-06-17T00:00:00.000Z') }],
+          cursor: 'shares-next',
+        } as never;
+      }
+      if (prefix === 'shares/' && cursor === 'shares-next') {
+        return {
+          blobs: [{ pathname: 'shares/new', url: 'https://blob/new-share', uploadedAt: new Date('2026-07-17T00:00:00.000Z') }],
+        } as never;
+      }
+      if (prefix === 'daily-suggestions/' && !cursor) {
+        return {
+          blobs: [
+            { pathname: 'daily-suggestions/2026-06-19.json', url: 'https://blob/retained', uploadedAt: new Date() },
+            { pathname: 'daily-suggestions/not-a-date.json', url: 'https://blob/malformed', uploadedAt: new Date() },
+          ],
+          cursor: 'daily-next',
+        } as never;
+      }
+      return {
+        blobs: [{ pathname: 'daily-suggestions/2026-06-18.json', url: 'https://blob/expired', uploadedAt: new Date() }],
+      } as never;
+    });
+    const res = makeRes();
+
+    await handler(request as never, res as never);
+
+    expect(list).toHaveBeenCalledWith({ prefix: 'shares/', cursor: undefined, limit: 1000 });
+    expect(list).toHaveBeenCalledWith({ prefix: 'shares/', cursor: 'shares-next', limit: 1000 });
+    expect(list).toHaveBeenCalledWith({ prefix: 'daily-suggestions/', cursor: undefined, limit: 1000 });
+    expect(list).toHaveBeenCalledWith({ prefix: 'daily-suggestions/', cursor: 'daily-next', limit: 1000 });
+    expect(del).toHaveBeenCalledWith(['https://blob/old-share']);
+    expect(del).toHaveBeenCalledWith(['https://blob/expired']);
+    expect(del).not.toHaveBeenCalledWith(expect.arrayContaining(['https://blob/retained', 'https://blob/malformed']));
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ deleted: 1, dailySuggestionsDeleted: 1, errors: [] });
+  });
+
+  it('continues daily cleanup when share listing fails', async () => {
+    vi.mocked(list).mockImplementation(async ({ prefix }) => {
+      if (prefix === 'shares/') throw new Error('share listing failed');
+      return {
+        blobs: [{ pathname: 'daily-suggestions/2026-06-18.json', url: 'https://blob/expired', uploadedAt: new Date() }],
+      } as never;
+    });
+    const res = makeRes();
+
+    await handler(request as never, res as never);
+
+    expect(list).toHaveBeenCalledWith({ prefix: 'daily-suggestions/', cursor: undefined, limit: 1000 });
+    expect(del).toHaveBeenCalledWith(['https://blob/expired']);
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ deleted: 0, dailySuggestionsDeleted: 1, errors: ['shares'] });
+    expect(console.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed when the Cron secret is not configured', async () => {
+    delete process.env.CRON_SECRET;
+    const res = makeRes();
+
+    await handler({ headers: { authorization: 'Bearer undefined' } } as never, res as never);
+
+    expect(res.statusCode).toBe(401);
+    expect(list).not.toHaveBeenCalled();
+  });
+});

--- a/api/cleanup.test.ts
+++ b/api/cleanup.test.ts
@@ -64,7 +64,7 @@ describe('cleanup handler', () => {
       return {
         blobs: [
           { pathname: 'daily-suggestions/2026-06-18.json', url: 'https://blob/expired', uploadedAt: new Date() },
-          { pathname: 'daily-suggestions/locks/2026-07-18.lock', url: 'https://blob/old-lock', uploadedAt: new Date('2026-07-17T03:59:59.000Z') },
+          { pathname: 'daily-suggestions/locks/2026-07-18.lock', url: 'https://blob/old-lock', etag: 'old-etag', uploadedAt: new Date('2026-07-17T03:59:59.000Z') },
         ],
       } as never;
     });
@@ -77,7 +77,8 @@ describe('cleanup handler', () => {
     expect(list).toHaveBeenCalledWith({ prefix: 'daily-suggestions/', cursor: undefined, limit: 1000 });
     expect(list).toHaveBeenCalledWith({ prefix: 'daily-suggestions/', cursor: 'daily-next', limit: 1000 });
     expect(del).toHaveBeenCalledWith(['https://blob/old-share']);
-    expect(del).toHaveBeenCalledWith(['https://blob/expired', 'https://blob/old-lock']);
+    expect(del).toHaveBeenCalledWith(['https://blob/expired']);
+    expect(del).toHaveBeenCalledWith('https://blob/old-lock', { ifMatch: 'old-etag' });
     expect(del).not.toHaveBeenCalledWith(expect.arrayContaining([
       'https://blob/retained',
       'https://blob/malformed',
@@ -103,6 +104,57 @@ describe('cleanup handler', () => {
     expect(del).toHaveBeenCalledWith(['https://blob/expired']);
     expect(res.statusCode).toBe(500);
     expect(res.body).toEqual({ deleted: 0, dailySuggestionsDeleted: 1, errors: ['shares'] });
+    expect(console.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('retains a replaced expired lock when its listed ETag no longer matches', async () => {
+    vi.mocked(list).mockImplementation(async ({ prefix }) => {
+      if (prefix === 'shares/') return { blobs: [] } as never;
+      return {
+        blobs: [{
+          pathname: 'daily-suggestions/locks/2026-07-18.lock',
+          url: 'https://blob/replaced-lock',
+          etag: 'etag-a',
+          uploadedAt: new Date('2026-07-17T03:59:59.000Z'),
+        }],
+      } as never;
+    });
+    vi.mocked(del).mockImplementation(async (_url, options) => {
+      if (options?.ifMatch === 'etag-a') {
+        throw Object.assign(new Error('lock was replaced with etag-b'), {
+          name: 'BlobPreconditionFailedError',
+        });
+      }
+    });
+    const res = makeRes();
+
+    await handler(request as never, res as never);
+
+    expect(del).toHaveBeenCalledWith('https://blob/replaced-lock', { ifMatch: 'etag-a' });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ deleted: 0, dailySuggestionsDeleted: 0, errors: [] });
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it('reports non-precondition lock deletion errors through daily job isolation', async () => {
+    vi.mocked(list).mockImplementation(async ({ prefix }) => {
+      if (prefix === 'shares/') return { blobs: [] } as never;
+      return {
+        blobs: [{
+          pathname: 'daily-suggestions/locks/2026-07-18.lock',
+          url: 'https://blob/broken-lock',
+          etag: 'old-etag',
+          uploadedAt: new Date('2026-07-17T03:59:59.000Z'),
+        }],
+      } as never;
+    });
+    vi.mocked(del).mockRejectedValue(new Error('blob service unavailable'));
+    const res = makeRes();
+
+    await handler(request as never, res as never);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual({ deleted: 0, dailySuggestionsDeleted: 0, errors: ['dailySuggestions'] });
     expect(console.error).toHaveBeenCalledTimes(1);
   });
 

--- a/api/cleanup.ts
+++ b/api/cleanup.ts
@@ -1,11 +1,11 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { list, del } from '@vercel/blob';
-import { beijingDate, expiredDailySuggestionUrls } from './daily-suggestions-core';
+import { beijingDate, expiredDailySuggestionCleanup } from './daily-suggestions-core';
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 
 async function allBlobs(prefix: string) {
-  const blobs: Array<{ pathname: string; url: string; uploadedAt: Date }> = [];
+  const blobs: Array<{ pathname: string; url: string; etag: string; uploadedAt: Date }> = [];
   let cursor: string | undefined;
   do {
     const page = await list({ prefix, cursor, limit: 1000 });
@@ -25,13 +25,23 @@ async function cleanupShares(now: Date): Promise<number> {
 }
 
 async function cleanupDailySuggestions(now: Date): Promise<number> {
-  const urls = expiredDailySuggestionUrls(
+  const cleanup = expiredDailySuggestionCleanup(
     await allBlobs('daily-suggestions/'),
     beijingDate(now),
     now,
   );
-  if (urls.length) await del(urls);
-  return urls.length;
+  if (cleanup.batchUrls.length) await del(cleanup.batchUrls);
+  let deleted = cleanup.batchUrls.length;
+  for (const lock of cleanup.locks) {
+    try {
+      await del(lock.url, { ifMatch: lock.etag });
+      deleted += 1;
+    } catch (error) {
+      if (error instanceof Error && error.name === 'BlobPreconditionFailedError') continue;
+      throw error;
+    }
+  }
+  return deleted;
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {

--- a/api/cleanup.ts
+++ b/api/cleanup.ts
@@ -28,6 +28,7 @@ async function cleanupDailySuggestions(now: Date): Promise<number> {
   const urls = expiredDailySuggestionUrls(
     await allBlobs('daily-suggestions/'),
     beijingDate(now),
+    now,
   );
   if (urls.length) await del(urls);
   return urls.length;

--- a/api/cleanup.ts
+++ b/api/cleanup.ts
@@ -1,37 +1,67 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { list, del } from '@vercel/blob';
+import { beijingDate, expiredDailySuggestionUrls } from './daily-suggestions-core';
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 
+async function allBlobs(prefix: string) {
+  const blobs: Array<{ pathname: string; url: string; uploadedAt: Date }> = [];
+  let cursor: string | undefined;
+  do {
+    const page = await list({ prefix, cursor, limit: 1000 });
+    blobs.push(...page.blobs);
+    cursor = page.cursor;
+  } while (cursor);
+  return blobs;
+}
+
+async function cleanupShares(now: Date): Promise<number> {
+  const cutoff = now.getTime() - THIRTY_DAYS_MS;
+  const urls = (await allBlobs('shares/'))
+    .filter((blob) => new Date(blob.uploadedAt).getTime() < cutoff)
+    .map((blob) => blob.url);
+  if (urls.length) await del(urls);
+  return urls.length;
+}
+
+async function cleanupDailySuggestions(now: Date): Promise<number> {
+  const urls = expiredDailySuggestionUrls(
+    await allBlobs('daily-suggestions/'),
+    beijingDate(now),
+  );
+  if (urls.length) await del(urls);
+  return urls.length;
+}
+
 export default async function handler(req: VercelRequest, res: VercelResponse) {
-  const authHeader = req.headers['authorization'];
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+  const secret = process.env.CRON_SECRET;
+  if (!secret || req.headers['authorization'] !== `Bearer ${secret}`) {
     res.status(401).json({ error: 'Unauthorized' });
     return;
   }
 
-  const cutoff = Date.now() - THIRTY_DAYS_MS;
-  let cursor: string | undefined;
-  let deleted = 0;
+  const jobs = [
+    { name: 'shares', run: cleanupShares },
+    { name: 'dailySuggestions', run: cleanupDailySuggestions },
+  ] as const;
+  const now = new Date();
+  const results = await Promise.allSettled(jobs.map((job) => job.run(now)));
+  const errors: string[] = [];
 
-  do {
-    const result = await list({
-      prefix: 'shares/',
-      cursor,
-      limit: 1000,
-    });
-
-    const toDelete = result.blobs
-      .filter((b) => new Date(b.uploadedAt).getTime() < cutoff)
-      .map((b) => b.url);
-
-    if (toDelete.length > 0) {
-      await del(toDelete);
-      deleted += toDelete.length;
+  results.forEach((result, index) => {
+    if (result.status === 'rejected') {
+      const job = jobs[index];
+      errors.push(job.name);
+      console.error(`Cleanup job failed: ${job.name}`, result.reason);
     }
+  });
 
-    cursor = result.cursor;
-  } while (cursor);
+  const deleted = results[0].status === 'fulfilled' ? results[0].value : 0;
+  const dailySuggestionsDeleted = results[1].status === 'fulfilled' ? results[1].value : 0;
 
-  res.status(200).json({ deleted });
+  res.status(errors.length ? 500 : 200).json({
+    deleted,
+    dailySuggestionsDeleted,
+    errors,
+  });
 }

--- a/api/daily-suggestions-core.test.ts
+++ b/api/daily-suggestions-core.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+  addDateDays,
+  beijingDate,
+  dailySuggestionPath,
+  expiredDailySuggestionUrls,
+  parseGeneratedItems,
+  parseStoredBatch,
+  readCandidateDates,
+  secondsUntilNextBeijingMidnight,
+  tomorrowInBeijing,
+} from './daily-suggestions-core';
+
+const items = Array.from({ length: 10 }, (_, i) => ({
+  zh: `想做一段第${i + 1}种有呼吸感的电子音乐`,
+  en: `I want electronic idea number ${i + 1} with a breathing pulse`,
+}));
+
+describe('daily suggestion server contract', () => {
+  it('uses Beijing dates across the UTC boundary', () => {
+    const now = new Date('2026-07-16T16:30:00.000Z');
+    expect(beijingDate(now)).toBe('2026-07-17');
+    expect(tomorrowInBeijing(now)).toBe('2026-07-18');
+    expect(secondsUntilNextBeijingMidnight(now)).toBe(84_600);
+  });
+
+  it('does calendar-safe date arithmetic and deterministic paths', () => {
+    expect(addDateDays('2026-03-01', -1)).toBe('2026-02-28');
+    expect(dailySuggestionPath('2026-07-18')).toBe('daily-suggestions/2026-07-18.json');
+    expect(readCandidateDates('2026-07-18')).toHaveLength(8);
+    expect(readCandidateDates('2026-07-18').at(-1)).toBe('2026-07-11');
+  });
+
+  it('accepts exactly ten unique bilingual generated items', () => {
+    expect(parseGeneratedItems({ items })).toEqual(items);
+    expect(parseGeneratedItems({ items: items.slice(0, 9) })).toBeNull();
+    expect(parseGeneratedItems({ items: [...items.slice(0, 9), items[0]] })).toBeNull();
+    expect(parseGeneratedItems({ items: [{ zh: '- 列表项', en: 'A valid English phrase' }, ...items.slice(1)] })).toBeNull();
+  });
+
+  it('requires the stored date and ISO generation timestamp', () => {
+    const batch = { date: '2026-07-18', generatedAt: '2026-07-17T15:30:00.000Z', items };
+    expect(parseStoredBatch(batch, '2026-07-18')).toEqual(batch);
+    expect(parseStoredBatch(batch, '2026-07-19')).toBeNull();
+  });
+
+  it('keeps 30 dates and ignores malformed paths', () => {
+    const blobs = [
+      { pathname: 'daily-suggestions/2026-06-18.json', url: 'old' },
+      { pathname: 'daily-suggestions/2026-06-19.json', url: 'keep' },
+      { pathname: 'daily-suggestions/not-a-date.json', url: 'unknown' },
+    ];
+    expect(expiredDailySuggestionUrls(blobs, '2026-07-18')).toEqual(['old']);
+  });
+});

--- a/api/daily-suggestions-core.test.ts
+++ b/api/daily-suggestions-core.test.ts
@@ -42,12 +42,15 @@ describe('daily suggestion server contract', () => {
     const batch = { date: '2026-07-18', generatedAt: '2026-07-17T15:30:00.000Z', items };
     expect(parseStoredBatch(batch, '2026-07-18')).toEqual(batch);
     expect(parseStoredBatch(batch, '2026-07-19')).toBeNull();
+    expect(parseStoredBatch({ ...batch, generatedAt: '2026-07-17' }, '2026-07-18')).toBeNull();
+    expect(parseStoredBatch({ ...batch, generatedAt: 'July 17, 2026 15:30 UTC' }, '2026-07-18')).toBeNull();
   });
 
   it('keeps 30 dates and ignores malformed paths', () => {
     const blobs = [
       { pathname: 'daily-suggestions/2026-06-18.json', url: 'old' },
       { pathname: 'daily-suggestions/2026-06-19.json', url: 'keep' },
+      { pathname: 'daily-suggestions/2026-00-00.json', url: 'impossible' },
       { pathname: 'daily-suggestions/not-a-date.json', url: 'unknown' },
     ];
     expect(expiredDailySuggestionUrls(blobs, '2026-07-18')).toEqual(['old']);

--- a/api/daily-suggestions-core.test.ts
+++ b/api/daily-suggestions-core.test.ts
@@ -55,4 +55,16 @@ describe('daily suggestion server contract', () => {
     ];
     expect(expiredDailySuggestionUrls(blobs, '2026-07-18')).toEqual(['old']);
   });
+
+  it('expires only well-formed daily locks older than 24 hours', () => {
+    const now = new Date('2026-07-18T04:00:00.000Z');
+    const blobs = [
+      { pathname: 'daily-suggestions/locks/2026-07-18.lock', url: 'old-lock', uploadedAt: new Date('2026-07-17T03:59:59.000Z') },
+      { pathname: 'daily-suggestions/locks/2026-07-19.lock', url: 'recent-lock', uploadedAt: new Date('2026-07-17T04:00:01.000Z') },
+      { pathname: 'daily-suggestions/locks/not-a-date.lock', url: 'malformed-lock', uploadedAt: new Date('2026-07-01T00:00:00.000Z') },
+      { pathname: 'daily-suggestions/locks/2026-00-00.lock', url: 'impossible-lock', uploadedAt: new Date('2026-07-01T00:00:00.000Z') },
+    ];
+
+    expect(expiredDailySuggestionUrls(blobs, '2026-07-18', now)).toEqual(['old-lock']);
+  });
 });

--- a/api/daily-suggestions-core.test.ts
+++ b/api/daily-suggestions-core.test.ts
@@ -3,6 +3,7 @@ import {
   addDateDays,
   beijingDate,
   dailySuggestionPath,
+  expiredDailySuggestionCleanup,
   expiredDailySuggestionUrls,
   parseGeneratedItems,
   parseStoredBatch,
@@ -59,12 +60,15 @@ describe('daily suggestion server contract', () => {
   it('expires only well-formed daily locks older than 24 hours', () => {
     const now = new Date('2026-07-18T04:00:00.000Z');
     const blobs = [
-      { pathname: 'daily-suggestions/locks/2026-07-18.lock', url: 'old-lock', uploadedAt: new Date('2026-07-17T03:59:59.000Z') },
-      { pathname: 'daily-suggestions/locks/2026-07-19.lock', url: 'recent-lock', uploadedAt: new Date('2026-07-17T04:00:01.000Z') },
-      { pathname: 'daily-suggestions/locks/not-a-date.lock', url: 'malformed-lock', uploadedAt: new Date('2026-07-01T00:00:00.000Z') },
-      { pathname: 'daily-suggestions/locks/2026-00-00.lock', url: 'impossible-lock', uploadedAt: new Date('2026-07-01T00:00:00.000Z') },
+      { pathname: 'daily-suggestions/locks/2026-07-18.lock', url: 'old-lock', etag: 'old-etag', uploadedAt: new Date('2026-07-17T03:59:59.000Z') },
+      { pathname: 'daily-suggestions/locks/2026-07-19.lock', url: 'recent-lock', etag: 'recent-etag', uploadedAt: new Date('2026-07-17T04:00:01.000Z') },
+      { pathname: 'daily-suggestions/locks/not-a-date.lock', url: 'malformed-lock', etag: 'malformed-etag', uploadedAt: new Date('2026-07-01T00:00:00.000Z') },
+      { pathname: 'daily-suggestions/locks/2026-00-00.lock', url: 'impossible-lock', etag: 'impossible-etag', uploadedAt: new Date('2026-07-01T00:00:00.000Z') },
     ];
 
-    expect(expiredDailySuggestionUrls(blobs, '2026-07-18', now)).toEqual(['old-lock']);
+    expect(expiredDailySuggestionCleanup(blobs, '2026-07-18', now)).toEqual({
+      batchUrls: [],
+      locks: [{ url: 'old-lock', etag: 'old-etag' }],
+    });
   });
 });

--- a/api/daily-suggestions-core.ts
+++ b/api/daily-suggestions-core.ts
@@ -60,11 +60,14 @@ function normalized(value: string): string {
   return value.normalize('NFKC').trim().replace(/\s+/g, ' ').toLocaleLowerCase();
 }
 
-function validText(value: unknown, language: 'zh' | 'en'): value is string {
+// Length is guided by the generation prompt, not gated here — an occasional
+// over-length item degrades chip display but is not worth discarding a whole
+// valid batch. Only structural garbage (empty, code fences, list numbering) is
+// rejected.
+function validText(value: unknown): value is string {
   if (typeof value !== 'string') return false;
   const text = value.trim();
-  const [min, max] = language === 'zh' ? [8, 80] : [16, 180];
-  return text.length >= min && text.length <= max && !text.includes('```') && !LIST_PREFIX_RE.test(text);
+  return text.length > 0 && !text.includes('```') && !LIST_PREFIX_RE.test(text);
 }
 
 function validIsoUtcTimestamp(value: string): boolean {
@@ -81,7 +84,7 @@ export function parseGeneratedItems(value: unknown): DailySuggestionItem[] | nul
   for (const item of candidate) {
     if (!item || typeof item !== 'object') return null;
     const { zh, en } = item as { zh?: unknown; en?: unknown };
-    if (!validText(zh, 'zh') || !validText(en, 'en')) return null;
+    if (!validText(zh) || !validText(en)) return null;
     items.push({ zh: zh.trim(), en: en.trim() });
   }
   if (new Set(items.map((item) => normalized(item.zh))).size !== 10) return null;

--- a/api/daily-suggestions-core.ts
+++ b/api/daily-suggestions-core.ts
@@ -1,0 +1,84 @@
+const DAY_MS = 86_400_000;
+const BEIJING_OFFSET_MS = 8 * 60 * 60 * 1000;
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const PATH_RE = /^daily-suggestions\/(\d{4}-\d{2}-\d{2})\.json$/;
+const LIST_PREFIX_RE = /^\s*(?:[-*]|\d+[.)])\s+/;
+
+export interface DailySuggestionItem { zh: string; en: string }
+export interface DailySuggestionBatch {
+  date: string;
+  generatedAt: string;
+  items: DailySuggestionItem[];
+}
+export interface DailySuggestionBlob { pathname: string; url: string }
+
+export function beijingDate(now = new Date()): string {
+  return new Date(now.getTime() + BEIJING_OFFSET_MS).toISOString().slice(0, 10);
+}
+
+export function addDateDays(date: string, days: number): string {
+  if (!DATE_RE.test(date)) throw new Error(`Invalid date: ${date}`);
+  return new Date(Date.parse(`${date}T00:00:00.000Z`) + days * DAY_MS).toISOString().slice(0, 10);
+}
+
+export function tomorrowInBeijing(now = new Date()): string {
+  return addDateDays(beijingDate(now), 1);
+}
+
+export function dailySuggestionPath(date: string): string {
+  if (!DATE_RE.test(date)) throw new Error(`Invalid date: ${date}`);
+  return `daily-suggestions/${date}.json`;
+}
+
+export function readCandidateDates(date: string): string[] {
+  return Array.from({ length: 8 }, (_, index) => addDateDays(date, -index));
+}
+
+export function secondsUntilNextBeijingMidnight(now = new Date()): number {
+  const shifted = now.getTime() + BEIJING_OFFSET_MS;
+  return Math.max(60, Math.ceil((DAY_MS - (shifted % DAY_MS)) / 1000));
+}
+
+function normalized(value: string): string {
+  return value.normalize('NFKC').trim().replace(/\s+/g, ' ').toLocaleLowerCase();
+}
+
+function validText(value: unknown, language: 'zh' | 'en'): value is string {
+  if (typeof value !== 'string') return false;
+  const text = value.trim();
+  const [min, max] = language === 'zh' ? [8, 80] : [16, 180];
+  return text.length >= min && text.length <= max && !text.includes('```') && !LIST_PREFIX_RE.test(text);
+}
+
+export function parseGeneratedItems(value: unknown): DailySuggestionItem[] | null {
+  if (!value || typeof value !== 'object') return null;
+  const candidate = (value as { items?: unknown }).items;
+  if (!Array.isArray(candidate) || candidate.length !== 10) return null;
+  const items: DailySuggestionItem[] = [];
+  for (const item of candidate) {
+    if (!item || typeof item !== 'object') return null;
+    const { zh, en } = item as { zh?: unknown; en?: unknown };
+    if (!validText(zh, 'zh') || !validText(en, 'en')) return null;
+    items.push({ zh: zh.trim(), en: en.trim() });
+  }
+  if (new Set(items.map((item) => normalized(item.zh))).size !== 10) return null;
+  if (new Set(items.map((item) => normalized(item.en))).size !== 10) return null;
+  return items;
+}
+
+export function parseStoredBatch(value: unknown, expectedDate: string): DailySuggestionBatch | null {
+  if (!value || typeof value !== 'object') return null;
+  const batch = value as Partial<DailySuggestionBatch>;
+  if (batch.date !== expectedDate || typeof batch.generatedAt !== 'string') return null;
+  if (!Number.isFinite(Date.parse(batch.generatedAt))) return null;
+  const items = parseGeneratedItems({ items: batch.items });
+  return items ? { date: expectedDate, generatedAt: batch.generatedAt, items } : null;
+}
+
+export function expiredDailySuggestionUrls(blobs: DailySuggestionBlob[], today: string): string[] {
+  const oldestRetainedDate = addDateDays(today, -29);
+  return blobs.flatMap((blob) => {
+    const date = PATH_RE.exec(blob.pathname)?.[1];
+    return date && date < oldestRetainedDate ? [blob.url] : [];
+  });
+}

--- a/api/daily-suggestions-core.ts
+++ b/api/daily-suggestions-core.ts
@@ -12,7 +12,16 @@ export interface DailySuggestionBatch {
   generatedAt: string;
   items: DailySuggestionItem[];
 }
-export interface DailySuggestionBlob { pathname: string; url: string; uploadedAt?: Date | string }
+export interface DailySuggestionBlob {
+  pathname: string;
+  url: string;
+  etag?: string;
+  uploadedAt?: Date | string;
+}
+export interface DailySuggestionCleanup {
+  batchUrls: string[];
+  locks: Array<{ url: string; etag: string }>;
+}
 
 export function beijingDate(now = new Date()): string {
   return new Date(now.getTime() + BEIJING_OFFSET_MS).toISOString().slice(0, 10);
@@ -94,17 +103,32 @@ export function expiredDailySuggestionUrls(
   today: string,
   now = new Date(),
 ): string[] {
+  return expiredDailySuggestionCleanup(blobs, today, now).batchUrls;
+}
+
+export function expiredDailySuggestionCleanup(
+  blobs: DailySuggestionBlob[],
+  today: string,
+  now = new Date(),
+): DailySuggestionCleanup {
   const oldestRetainedDate = addDateDays(today, -29);
   const lockCutoff = now.getTime() - DAY_MS;
-  return blobs.flatMap((blob) => {
+  const cleanup: DailySuggestionCleanup = { batchUrls: [], locks: [] };
+  for (const blob of blobs) {
     const date = PATH_RE.exec(blob.pathname)?.[1];
-    if (date) return validDate(date) && date < oldestRetainedDate ? [blob.url] : [];
+    if (date) {
+      if (validDate(date) && date < oldestRetainedDate) cleanup.batchUrls.push(blob.url);
+      continue;
+    }
 
     const lockDate = LOCK_PATH_RE.exec(blob.pathname)?.[1];
-    if (!lockDate || !validDate(lockDate) || blob.uploadedAt === undefined) return [];
+    if (!lockDate || !validDate(lockDate) || blob.uploadedAt === undefined || !blob.etag) continue;
     const uploadedAt = blob.uploadedAt instanceof Date
       ? blob.uploadedAt.getTime()
       : Date.parse(blob.uploadedAt);
-    return Number.isFinite(uploadedAt) && uploadedAt < lockCutoff ? [blob.url] : [];
-  });
+    if (Number.isFinite(uploadedAt) && uploadedAt < lockCutoff) {
+      cleanup.locks.push({ url: blob.url, etag: blob.etag });
+    }
+  }
+  return cleanup;
 }

--- a/api/daily-suggestions-core.ts
+++ b/api/daily-suggestions-core.ts
@@ -2,6 +2,7 @@ const DAY_MS = 86_400_000;
 const BEIJING_OFFSET_MS = 8 * 60 * 60 * 1000;
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const PATH_RE = /^daily-suggestions\/(\d{4}-\d{2}-\d{2})\.json$/;
+const LOCK_PATH_RE = /^daily-suggestions\/locks\/(\d{4}-\d{2}-\d{2})\.lock$/;
 const ISO_UTC_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 const LIST_PREFIX_RE = /^\s*(?:[-*]|\d+[.)])\s+/;
 
@@ -11,7 +12,7 @@ export interface DailySuggestionBatch {
   generatedAt: string;
   items: DailySuggestionItem[];
 }
-export interface DailySuggestionBlob { pathname: string; url: string }
+export interface DailySuggestionBlob { pathname: string; url: string; uploadedAt?: Date | string }
 
 export function beijingDate(now = new Date()): string {
   return new Date(now.getTime() + BEIJING_OFFSET_MS).toISOString().slice(0, 10);
@@ -88,10 +89,22 @@ export function parseStoredBatch(value: unknown, expectedDate: string): DailySug
   return items ? { date: expectedDate, generatedAt: batch.generatedAt, items } : null;
 }
 
-export function expiredDailySuggestionUrls(blobs: DailySuggestionBlob[], today: string): string[] {
+export function expiredDailySuggestionUrls(
+  blobs: DailySuggestionBlob[],
+  today: string,
+  now = new Date(),
+): string[] {
   const oldestRetainedDate = addDateDays(today, -29);
+  const lockCutoff = now.getTime() - DAY_MS;
   return blobs.flatMap((blob) => {
     const date = PATH_RE.exec(blob.pathname)?.[1];
-    return date && validDate(date) && date < oldestRetainedDate ? [blob.url] : [];
+    if (date) return validDate(date) && date < oldestRetainedDate ? [blob.url] : [];
+
+    const lockDate = LOCK_PATH_RE.exec(blob.pathname)?.[1];
+    if (!lockDate || !validDate(lockDate) || blob.uploadedAt === undefined) return [];
+    const uploadedAt = blob.uploadedAt instanceof Date
+      ? blob.uploadedAt.getTime()
+      : Date.parse(blob.uploadedAt);
+    return Number.isFinite(uploadedAt) && uploadedAt < lockCutoff ? [blob.url] : [];
   });
 }

--- a/api/daily-suggestions-core.ts
+++ b/api/daily-suggestions-core.ts
@@ -43,7 +43,7 @@ export function readCandidateDates(date: string): string[] {
 
 export function secondsUntilNextBeijingMidnight(now = new Date()): number {
   const shifted = now.getTime() + BEIJING_OFFSET_MS;
-  return Math.max(60, Math.ceil((DAY_MS - (shifted % DAY_MS)) / 1000));
+  return Math.max(1, Math.ceil((DAY_MS - (shifted % DAY_MS)) / 1000));
 }
 
 function normalized(value: string): string {

--- a/api/daily-suggestions-core.ts
+++ b/api/daily-suggestions-core.ts
@@ -2,6 +2,7 @@ const DAY_MS = 86_400_000;
 const BEIJING_OFFSET_MS = 8 * 60 * 60 * 1000;
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 const PATH_RE = /^daily-suggestions\/(\d{4}-\d{2}-\d{2})\.json$/;
+const ISO_UTC_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 const LIST_PREFIX_RE = /^\s*(?:[-*]|\d+[.)])\s+/;
 
 export interface DailySuggestionItem { zh: string; en: string }
@@ -16,8 +17,14 @@ export function beijingDate(now = new Date()): string {
   return new Date(now.getTime() + BEIJING_OFFSET_MS).toISOString().slice(0, 10);
 }
 
+function validDate(date: string): boolean {
+  if (!DATE_RE.test(date)) return false;
+  const timestamp = Date.parse(`${date}T00:00:00.000Z`);
+  return Number.isFinite(timestamp) && new Date(timestamp).toISOString().slice(0, 10) === date;
+}
+
 export function addDateDays(date: string, days: number): string {
-  if (!DATE_RE.test(date)) throw new Error(`Invalid date: ${date}`);
+  if (!validDate(date)) throw new Error(`Invalid date: ${date}`);
   return new Date(Date.parse(`${date}T00:00:00.000Z`) + days * DAY_MS).toISOString().slice(0, 10);
 }
 
@@ -26,7 +33,7 @@ export function tomorrowInBeijing(now = new Date()): string {
 }
 
 export function dailySuggestionPath(date: string): string {
-  if (!DATE_RE.test(date)) throw new Error(`Invalid date: ${date}`);
+  if (!validDate(date)) throw new Error(`Invalid date: ${date}`);
   return `daily-suggestions/${date}.json`;
 }
 
@@ -50,6 +57,12 @@ function validText(value: unknown, language: 'zh' | 'en'): value is string {
   return text.length >= min && text.length <= max && !text.includes('```') && !LIST_PREFIX_RE.test(text);
 }
 
+function validIsoUtcTimestamp(value: string): boolean {
+  if (!ISO_UTC_RE.test(value)) return false;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) && new Date(timestamp).toISOString() === value;
+}
+
 export function parseGeneratedItems(value: unknown): DailySuggestionItem[] | null {
   if (!value || typeof value !== 'object') return null;
   const candidate = (value as { items?: unknown }).items;
@@ -70,7 +83,7 @@ export function parseStoredBatch(value: unknown, expectedDate: string): DailySug
   if (!value || typeof value !== 'object') return null;
   const batch = value as Partial<DailySuggestionBatch>;
   if (batch.date !== expectedDate || typeof batch.generatedAt !== 'string') return null;
-  if (!Number.isFinite(Date.parse(batch.generatedAt))) return null;
+  if (!validIsoUtcTimestamp(batch.generatedAt)) return null;
   const items = parseGeneratedItems({ items: batch.items });
   return items ? { date: expectedDate, generatedAt: batch.generatedAt, items } : null;
 }
@@ -79,6 +92,6 @@ export function expiredDailySuggestionUrls(blobs: DailySuggestionBlob[], today: 
   const oldestRetainedDate = addDateDays(today, -29);
   return blobs.flatMap((blob) => {
     const date = PATH_RE.exec(blob.pathname)?.[1];
-    return date && date < oldestRetainedDate ? [blob.url] : [];
+    return date && validDate(date) && date < oldestRetainedDate ? [blob.url] : [];
   });
 }

--- a/api/daily-suggestions-generate.test.ts
+++ b/api/daily-suggestions-generate.test.ts
@@ -146,35 +146,134 @@ describe('daily-suggestions-generate handler', () => {
     );
   });
 
-  it('atomically claims a date so two concurrent handlers call the model at most once', async () => {
+  it('waits for a successful winner and returns exists without a second model call', async () => {
     const notFound = Object.assign(new Error('not found'), { name: 'BlobNotFoundError' });
-    vi.mocked(head).mockRejectedValue(notFound);
-    let lockClaimed = false;
+    let lockEtag: string | null = null;
+    let finalStored = false;
+    vi.mocked(head).mockImplementation(async (pathname) => {
+      if (pathname.endsWith('.json') && finalStored) return { pathname } as never;
+      if (pathname.includes('/locks/') && lockEtag) {
+        return { etag: lockEtag, uploadedAt: new Date() } as never;
+      }
+      throw notFound;
+    });
     vi.mocked(put).mockImplementation(async (pathname) => {
       if (pathname.includes('/locks/')) {
-        if (lockClaimed) throw Object.assign(new Error('already exists'), { name: 'BlobPreconditionFailedError' });
-        lockClaimed = true;
-        return { etag: 'winner-etag' } as never;
+        if (lockEtag) throw Object.assign(new Error('already exists'), { name: 'BlobPreconditionFailedError' });
+        lockEtag = 'winner-etag';
+        return { etag: lockEtag } as never;
       }
+      finalStored = true;
       return {} as never;
     });
-    let resolveModel!: (response: Response) => void;
-    const modelResponse = new Promise<Response>((resolve) => { resolveModel = resolve; });
-    vi.stubGlobal('fetch', vi.fn().mockReturnValue(modelResponse));
+    vi.mocked(del).mockImplementation(async (_pathname, options) => {
+      if (options?.ifMatch === lockEtag) lockEtag = null;
+    });
+    let resolveWinner!: (response: Response) => void;
+    const winnerResponse = new Promise<Response>((resolve) => { resolveWinner = resolve; });
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(winnerResponse));
     const firstRes = makeRes();
     const secondRes = makeRes();
 
     const first = handler(authorizedReq() as never, firstRes as never);
     await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
-    await handler(authorizedReq() as never, secondRes as never);
-    resolveModel(new Response(JSON.stringify({
+    const second = handler(authorizedReq() as never, secondRes as never);
+    resolveWinner(new Response(JSON.stringify({
       choices: [{ message: { content: JSON.stringify({ items }) } }],
     }), { status: 200 }));
     await first;
+    await vi.advanceTimersByTimeAsync(100);
+    await second;
 
     expect(fetch).toHaveBeenCalledTimes(1);
-    expect(secondRes.statusCode).toBe(202);
-    expect(secondRes.body).toEqual({ status: 'in-progress', date: '2026-07-18', attempts: 0 });
+    expect(secondRes.statusCode).toBe(200);
+    expect(secondRes.body).toEqual({ status: 'exists', date: '2026-07-18', attempts: 0 });
+  });
+
+  it('lets a waiting loser claim after winner failure without overlapping model calls', async () => {
+    const notFound = Object.assign(new Error('not found'), { name: 'BlobNotFoundError' });
+    let lockEtag: string | null = null;
+    let lockNumber = 0;
+    let finalStored = false;
+    vi.mocked(head).mockImplementation(async (pathname) => {
+      if (pathname.endsWith('.json') && finalStored) return { pathname } as never;
+      if (pathname.includes('/locks/') && lockEtag) {
+        return { etag: lockEtag, uploadedAt: new Date() } as never;
+      }
+      throw notFound;
+    });
+    vi.mocked(put).mockImplementation(async (pathname) => {
+      if (pathname.includes('/locks/')) {
+        if (lockEtag) throw Object.assign(new Error('already exists'), { name: 'BlobPreconditionFailedError' });
+        lockNumber += 1;
+        lockEtag = `owner-${lockNumber}`;
+        return { etag: lockEtag } as never;
+      }
+      finalStored = true;
+      return {} as never;
+    });
+    vi.mocked(del).mockImplementation(async (_pathname, options) => {
+      if (options?.ifMatch === lockEtag) lockEtag = null;
+    });
+    const pendingResolvers: Array<(response: Response) => void> = [];
+    let activeModelCalls = 0;
+    let maxActiveModelCalls = 0;
+    vi.stubGlobal('fetch', vi.fn().mockImplementation(() => {
+      activeModelCalls += 1;
+      maxActiveModelCalls = Math.max(maxActiveModelCalls, activeModelCalls);
+      return new Promise<Response>((resolve) => {
+        pendingResolvers.push((response) => {
+          activeModelCalls -= 1;
+          resolve(response);
+        });
+      });
+    }));
+    const winnerRes = makeRes();
+    const loserRes = makeRes();
+
+    const winner = handler(authorizedReq() as never, winnerRes as never);
+    await vi.waitFor(() => expect(pendingResolvers).toHaveLength(1));
+    const loser = handler(authorizedReq() as never, loserRes as never);
+    pendingResolvers.shift()!(new Response('unavailable', { status: 503 }));
+    await vi.waitFor(() => expect(pendingResolvers).toHaveLength(1));
+    pendingResolvers.shift()!(new Response('still unavailable', { status: 503 }));
+    await winner;
+    await vi.advanceTimersByTimeAsync(100);
+    await vi.waitFor(() => expect(pendingResolvers).toHaveLength(1));
+    pendingResolvers.shift()!(new Response(JSON.stringify({
+      choices: [{ message: { content: JSON.stringify({ items }) } }],
+    }), { status: 200 }));
+    await loser;
+
+    expect(winnerRes.statusCode).toBe(502);
+    expect(loserRes.body).toMatchObject({ status: 'created', date: '2026-07-18' });
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(maxActiveModelCalls).toBe(1);
+  });
+
+  it('returns an error when bounded polling expires with a valid owner', async () => {
+    const notFound = Object.assign(new Error('not found'), { name: 'BlobNotFoundError' });
+    vi.mocked(head).mockImplementation(async (pathname) => {
+      if (pathname.includes('/locks/')) {
+        return { etag: 'active-owner', uploadedAt: new Date() } as never;
+      }
+      throw notFound;
+    });
+    vi.mocked(put).mockRejectedValue(
+      Object.assign(new Error('already exists'), { name: 'BlobPreconditionFailedError' }),
+    );
+    const res = makeRes();
+
+    const pending = handler(authorizedReq() as never, res as never);
+    await vi.runAllTimersAsync();
+    await pending;
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toEqual({
+      error: 'Daily suggestion generation is still in progress',
+      date: '2026-07-18',
+    });
+    expect(fetch).not.toHaveBeenCalled();
   });
 
   it('recovers an abandoned lock with an ETag-guarded delete', async () => {
@@ -185,7 +284,8 @@ describe('daily-suggestions-generate handler', () => {
       .mockResolvedValueOnce({
         uploadedAt: new Date('2026-07-17T15:20:00.000Z'),
         etag: 'stale-etag',
-      } as never);
+      } as never)
+      .mockRejectedValueOnce(notFound);
     vi.mocked(put)
       .mockRejectedValueOnce(Object.assign(new Error('already exists'), { name: 'BlobPreconditionFailedError' }))
       .mockResolvedValueOnce({ etag: 'fresh-etag' } as never)

--- a/api/daily-suggestions-generate.test.ts
+++ b/api/daily-suggestions-generate.test.ts
@@ -41,6 +41,7 @@ describe('daily-suggestions-generate handler', () => {
     vi.stubGlobal('fetch', vi.fn());
     vi.spyOn(console, 'info').mockImplementation(() => undefined);
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    delete process.env.VITE_API_KEY;
     process.env.CRON_SECRET = 'cron-secret';
     process.env.OFFICIAL_API_KEY = 'official-api-key';
   });
@@ -50,7 +51,9 @@ describe('daily-suggestions-generate handler', () => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
     vi.resetAllMocks();
+    delete process.env.CRON_SECRET;
     delete process.env.OFFICIAL_API_KEY;
+    delete process.env.VITE_API_KEY;
   });
 
   it('rejects a request without the Cron bearer token', async () => {
@@ -59,6 +62,30 @@ describe('daily-suggestions-generate handler', () => {
     await handler({ method: 'GET', headers: {} } as never, res as never);
 
     expect(res.statusCode).toBe(401);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects Bearer undefined when the Cron secret is not configured', async () => {
+    delete process.env.CRON_SECRET;
+    const res = makeRes();
+
+    await handler({
+      method: 'GET',
+      headers: { authorization: 'Bearer undefined' },
+    } as never, res as never);
+
+    expect(res.statusCode).toBe(401);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('does not use the client Vite API key for server-side generation', async () => {
+    delete process.env.OFFICIAL_API_KEY;
+    process.env.VITE_API_KEY = 'client-api-key';
+    const res = makeRes();
+
+    await handler(authorizedReq() as never, res as never);
+
+    expect(res.statusCode).toBe(500);
     expect(fetch).not.toHaveBeenCalled();
   });
 

--- a/api/daily-suggestions-generate.test.ts
+++ b/api/daily-suggestions-generate.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { head, put } from '@vercel/blob';
+import handler from './daily-suggestions-generate';
+
+vi.mock('@vercel/blob', () => ({ head: vi.fn(), put: vi.fn() }));
+
+const items = Array.from({ length: 10 }, (_, i) => ({
+  zh: `想做一段第${i + 1}种带空间变化的电子音乐`,
+  en: `I want electronic idea number ${i + 1} with changing space`,
+}));
+
+function makeRes() {
+  return {
+    statusCode: 0,
+    body: undefined as unknown,
+    headers: {} as Record<string, string | number | readonly string[]>,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body: unknown) {
+      this.body = body;
+      return this;
+    },
+    setHeader(name: string, value: string | number | readonly string[]) {
+      this.headers[name] = value;
+      return this;
+    },
+  };
+}
+
+function authorizedReq() {
+  return { method: 'GET', headers: { authorization: 'Bearer cron-secret' } };
+}
+
+describe('daily-suggestions-generate handler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime('2026-07-17T15:30:00.000Z');
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn());
+    vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    process.env.CRON_SECRET = 'cron-secret';
+    process.env.OFFICIAL_API_KEY = 'official-api-key';
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    vi.resetAllMocks();
+    delete process.env.OFFICIAL_API_KEY;
+  });
+
+  it('rejects a request without the Cron bearer token', async () => {
+    const res = makeRes();
+
+    await handler({ method: 'GET', headers: {} } as never, res as never);
+
+    expect(res.statusCode).toBe(401);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('returns exists without calling the model when tomorrow is stored', async () => {
+    vi.mocked(head).mockResolvedValue({ pathname: 'daily-suggestions/2026-07-18.json' } as never);
+    const res = makeRes();
+
+    await handler(authorizedReq() as never, res as never);
+
+    expect(res.body).toMatchObject({ status: 'exists', date: '2026-07-18', attempts: 0 });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('writes a valid model response to tomorrow immutable path', async () => {
+    vi.mocked(head).mockRejectedValue(Object.assign(new Error('not found'), { name: 'BlobNotFoundError' }));
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      choices: [{ message: { content: JSON.stringify({ items }) } }],
+    }), { status: 200 })));
+    const res = makeRes();
+
+    await handler(authorizedReq() as never, res as never);
+
+    expect(put).toHaveBeenCalledWith(
+      'daily-suggestions/2026-07-18.json',
+      expect.stringContaining('"date":"2026-07-18"'),
+      expect.objectContaining({ access: 'public', addRandomSuffix: false }),
+    );
+    expect(res.body).toMatchObject({ status: 'created', attempts: 1 });
+  });
+
+  it('retries invalid output once and never stores invalid data', async () => {
+    vi.mocked(head).mockRejectedValue(Object.assign(new Error('not found'), { name: 'BlobNotFoundError' }));
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      choices: [{ message: { content: '{"items":[]}' } }],
+    }), { status: 200 })));
+    const res = makeRes();
+
+    await handler(authorizedReq() as never, res as never);
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(put).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(502);
+  });
+});

--- a/api/daily-suggestions-generate.test.ts
+++ b/api/daily-suggestions-generate.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { head, put } from '@vercel/blob';
+import { del, head, put } from '@vercel/blob';
 import handler from './daily-suggestions-generate';
 
-vi.mock('@vercel/blob', () => ({ head: vi.fn(), put: vi.fn() }));
+vi.mock('@vercel/blob', () => ({ del: vi.fn(), head: vi.fn(), put: vi.fn() }));
 
 const items = Array.from({ length: 10 }, (_, i) => ({
   zh: `想做一段第${i + 1}种带空间变化的电子音乐`,
@@ -101,6 +101,9 @@ describe('daily-suggestions-generate handler', () => {
 
   it('writes a valid model response to tomorrow immutable path', async () => {
     vi.mocked(head).mockRejectedValue(Object.assign(new Error('not found'), { name: 'BlobNotFoundError' }));
+    vi.mocked(put)
+      .mockResolvedValueOnce({ etag: 'lock-etag' } as never)
+      .mockResolvedValueOnce({} as never);
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
       choices: [{ message: { content: JSON.stringify({ items }) } }],
     }), { status: 200 })));
@@ -113,11 +116,16 @@ describe('daily-suggestions-generate handler', () => {
       expect.stringContaining('"date":"2026-07-18"'),
       expect.objectContaining({ access: 'public', addRandomSuffix: false }),
     );
+    expect(del).toHaveBeenCalledWith(
+      'daily-suggestions/locks/2026-07-18.lock',
+      { ifMatch: 'lock-etag' },
+    );
     expect(res.body).toMatchObject({ status: 'created', attempts: 1 });
   });
 
   it('retries invalid output once and never stores invalid data', async () => {
     vi.mocked(head).mockRejectedValue(Object.assign(new Error('not found'), { name: 'BlobNotFoundError' }));
+    vi.mocked(put).mockResolvedValueOnce({ etag: 'lock-etag' } as never);
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
       choices: [{ message: { content: '{"items":[]}' } }],
     }), { status: 200 })));
@@ -126,7 +134,118 @@ describe('daily-suggestions-generate handler', () => {
     await handler(authorizedReq() as never, res as never);
 
     expect(fetch).toHaveBeenCalledTimes(2);
-    expect(put).not.toHaveBeenCalled();
+    expect(put).not.toHaveBeenCalledWith(
+      'daily-suggestions/2026-07-18.json',
+      expect.anything(),
+      expect.anything(),
+    );
     expect(res.statusCode).toBe(502);
+    expect(del).toHaveBeenCalledWith(
+      'daily-suggestions/locks/2026-07-18.lock',
+      { ifMatch: 'lock-etag' },
+    );
+  });
+
+  it('atomically claims a date so two concurrent handlers call the model at most once', async () => {
+    const notFound = Object.assign(new Error('not found'), { name: 'BlobNotFoundError' });
+    vi.mocked(head).mockRejectedValue(notFound);
+    let lockClaimed = false;
+    vi.mocked(put).mockImplementation(async (pathname) => {
+      if (pathname.includes('/locks/')) {
+        if (lockClaimed) throw Object.assign(new Error('already exists'), { name: 'BlobPreconditionFailedError' });
+        lockClaimed = true;
+        return { etag: 'winner-etag' } as never;
+      }
+      return {} as never;
+    });
+    let resolveModel!: (response: Response) => void;
+    const modelResponse = new Promise<Response>((resolve) => { resolveModel = resolve; });
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(modelResponse));
+    const firstRes = makeRes();
+    const secondRes = makeRes();
+
+    const first = handler(authorizedReq() as never, firstRes as never);
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    await handler(authorizedReq() as never, secondRes as never);
+    resolveModel(new Response(JSON.stringify({
+      choices: [{ message: { content: JSON.stringify({ items }) } }],
+    }), { status: 200 }));
+    await first;
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(secondRes.statusCode).toBe(202);
+    expect(secondRes.body).toEqual({ status: 'in-progress', date: '2026-07-18', attempts: 0 });
+  });
+
+  it('recovers an abandoned lock with an ETag-guarded delete', async () => {
+    const notFound = Object.assign(new Error('not found'), { name: 'BlobNotFoundError' });
+    vi.mocked(head)
+      .mockRejectedValueOnce(notFound)
+      .mockRejectedValueOnce(notFound)
+      .mockResolvedValueOnce({
+        uploadedAt: new Date('2026-07-17T15:20:00.000Z'),
+        etag: 'stale-etag',
+      } as never);
+    vi.mocked(put)
+      .mockRejectedValueOnce(Object.assign(new Error('already exists'), { name: 'BlobPreconditionFailedError' }))
+      .mockResolvedValueOnce({ etag: 'fresh-etag' } as never)
+      .mockResolvedValueOnce({} as never);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      choices: [{ message: { content: JSON.stringify({ items }) } }],
+    }), { status: 200 })));
+    const res = makeRes();
+
+    await handler(authorizedReq() as never, res as never);
+
+    expect(del).toHaveBeenNthCalledWith(
+      1,
+      'daily-suggestions/locks/2026-07-18.lock',
+      { ifMatch: 'stale-etag' },
+    );
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(res.body).toMatchObject({ status: 'created', date: '2026-07-18' });
+  });
+
+  it('categorizes malformed model JSON as invalid output', async () => {
+    vi.mocked(head).mockRejectedValue(Object.assign(new Error('not found'), { name: 'BlobNotFoundError' }));
+    vi.mocked(put).mockResolvedValueOnce({ etag: 'lock-etag' } as never);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      choices: [{ message: { content: '{not valid JSON' } }],
+    }), { status: 200 })));
+    const res = makeRes();
+
+    await handler(authorizedReq() as never, res as never);
+
+    expect(console.info).toHaveBeenNthCalledWith(1, 'daily_suggestions_generation_attempt', {
+      date: '2026-07-18', attempt: 1, outcome: 'invalid_output',
+    });
+    expect(console.info).toHaveBeenNthCalledWith(2, 'daily_suggestions_generation_attempt', {
+      date: '2026-07-18', attempt: 2, outcome: 'invalid_output',
+    });
+  });
+
+  it('logs sanitized attempt outcomes without model content or credentials', async () => {
+    vi.mocked(head).mockRejectedValue(Object.assign(new Error('not found'), { name: 'BlobNotFoundError' }));
+    vi.mocked(put)
+      .mockResolvedValueOnce({ etag: 'lock-etag' } as never)
+      .mockResolvedValueOnce({} as never);
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(new Response('upstream unavailable', { status: 503 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        choices: [{ message: { content: JSON.stringify({ items }) } }],
+      }), { status: 200 })));
+    const res = makeRes();
+
+    await handler(authorizedReq() as never, res as never);
+
+    expect(console.info).toHaveBeenCalledWith('daily_suggestions_generation_attempt', {
+      date: '2026-07-18', attempt: 1, outcome: 'upstream_failure',
+    });
+    expect(console.info).toHaveBeenCalledWith('daily_suggestions_generation_attempt', {
+      date: '2026-07-18', attempt: 2, outcome: 'stored',
+    });
+    const logged = JSON.stringify(vi.mocked(console.info).mock.calls);
+    expect(logged).not.toContain('official-api-key');
+    expect(logged).not.toContain(items[0].zh);
   });
 });

--- a/api/daily-suggestions-generate.ts
+++ b/api/daily-suggestions-generate.ts
@@ -1,5 +1,5 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { head, put } from '@vercel/blob';
+import { del, head, put } from '@vercel/blob';
 import {
   dailySuggestionPath,
   parseGeneratedItems,
@@ -9,6 +9,7 @@ import {
 
 const UPSTREAM = 'https://api.deepseek.com/v1/chat/completions';
 const MODEL = 'deepseek-v4-pro';
+const LOCK_STALE_MS = 5 * 60 * 1000;
 
 const DAILY_SUGGESTION_SYSTEM_PROMPT = `# Goal
 Create a fresh daily batch of entry suggestions that users can send directly to an AI music-making agent.
@@ -44,31 +45,93 @@ async function exists(pathname: string): Promise<boolean> {
   }
 }
 
-async function generateItems(apiKey: string) {
-  const response = await fetch(UPSTREAM, {
-    method: 'POST',
-    headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      model: MODEL,
-      stream: false,
-      temperature: 1,
-      max_tokens: 1800,
-      response_format: { type: 'json_object' },
-      messages: [
-        { role: 'system', content: DAILY_SUGGESTION_SYSTEM_PROMPT },
-        { role: 'user', content: 'Generate today\'s 10 bilingual entry suggestions.' },
-      ],
-    }),
-  });
-  if (!response.ok) throw new Error(`Model request failed: ${response.status}`);
-  const json = await response.json() as { choices?: Array<{ message?: { content?: string } }> };
-  const content = json.choices?.[0]?.message?.content;
-  if (!content) return null;
+type GenerationResult =
+  | { outcome: 'valid'; items: DailySuggestionBatch['items'] }
+  | { outcome: 'upstream_failure' | 'invalid_output' };
+
+function isNotFound(error: unknown): boolean {
+  return error instanceof Error && error.name === 'BlobNotFoundError';
+}
+
+async function generateItems(apiKey: string): Promise<GenerationResult> {
+  let response: Response;
   try {
-    return parseGeneratedItems(JSON.parse(content));
+    response = await fetch(UPSTREAM, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: MODEL,
+        stream: false,
+        temperature: 1,
+        max_tokens: 1800,
+        response_format: { type: 'json_object' },
+        messages: [
+          { role: 'system', content: DAILY_SUGGESTION_SYSTEM_PROMPT },
+          { role: 'user', content: 'Generate today\'s 10 bilingual entry suggestions.' },
+        ],
+      }),
+    });
   } catch {
-    return null;
+    return { outcome: 'upstream_failure' };
   }
+  if (!response.ok) return { outcome: 'upstream_failure' };
+  try {
+    const json = await response.json() as { choices?: Array<{ message?: { content?: string } }> };
+    const content = json.choices?.[0]?.message?.content;
+    if (!content) return { outcome: 'invalid_output' };
+    const items = parseGeneratedItems(JSON.parse(content));
+    return items ? { outcome: 'valid', items } : { outcome: 'invalid_output' };
+  } catch {
+    return { outcome: 'invalid_output' };
+  }
+}
+
+function lockPath(date: string): string {
+  return `daily-suggestions/locks/${date}.lock`;
+}
+
+type ClaimResult =
+  | { status: 'acquired'; pathname: string; etag: string }
+  | { status: 'exists' | 'in-progress' };
+
+async function claimDate(date: string, finalPath: string): Promise<ClaimResult> {
+  const pathname = lockPath(date);
+  for (let claimAttempt = 0; claimAttempt < 2; claimAttempt += 1) {
+    try {
+      const lock = await put(pathname, JSON.stringify({ date, claimedAt: new Date().toISOString() }), {
+        access: 'public',
+        addRandomSuffix: false,
+        allowOverwrite: false,
+        contentType: 'application/json',
+        cacheControlMaxAge: 60,
+      });
+      return { status: 'acquired', pathname, etag: lock.etag };
+    } catch {
+      if (await exists(finalPath)) return { status: 'exists' };
+      try {
+        const lock = await head(pathname);
+        if (Date.now() - lock.uploadedAt.getTime() <= LOCK_STALE_MS) {
+          return { status: 'in-progress' };
+        }
+        await del(pathname, { ifMatch: lock.etag });
+      } catch (error) {
+        if (!isNotFound(error)) return { status: 'in-progress' };
+      }
+    }
+  }
+  return { status: 'in-progress' };
+}
+
+async function releaseClaim(claim: Extract<ClaimResult, { status: 'acquired' }>) {
+  try {
+    await del(claim.pathname, { ifMatch: claim.etag });
+  } catch {
+    // A stale-recovery winner may already have replaced this lock. Never delete without ETag ownership.
+  }
+}
+
+function logAttempt(date: string, attempt: number, outcome: string) {
+  console.info('daily_suggestions_generation_attempt', { date, attempt, outcome });
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -84,21 +147,46 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const pathname = dailySuggestionPath(date);
   if (await exists(pathname)) return void res.status(200).json({ status: 'exists', date, attempts: 0 });
 
-  for (let attempts = 1; attempts <= 2; attempts += 1) {
-    const items = await generateItems(apiKey).catch(() => null);
-    if (!items) continue;
-    const batch: DailySuggestionBatch = { date, generatedAt: new Date().toISOString(), items };
-    try {
-      await put(pathname, JSON.stringify(batch), {
-        access: 'public', addRandomSuffix: false, contentType: 'application/json', cacheControlMaxAge: 2_678_400,
-      });
-      console.info('daily_suggestions_generated', { date, pathname, attempts });
-      return void res.status(200).json({ status: 'created', date, attempts });
-    } catch (error) {
-      if (await exists(pathname)) return void res.status(200).json({ status: 'exists', date, attempts });
-      throw error;
-    }
+  const claim = await claimDate(date, pathname);
+  if (claim.status === 'exists') {
+    return void res.status(200).json({ status: 'exists', date, attempts: 0 });
   }
-  console.error('daily_suggestions_generation_failed', { date });
-  res.status(502).json({ error: 'Failed to generate valid daily suggestions', date });
+  if (claim.status === 'in-progress') {
+    return void res.status(202).json({ status: 'in-progress', date, attempts: 0 });
+  }
+
+  try {
+    for (let attempts = 1; attempts <= 2; attempts += 1) {
+      const generated = await generateItems(apiKey);
+      if (generated.outcome !== 'valid') {
+        logAttempt(date, attempts, generated.outcome);
+        continue;
+      }
+      const batch: DailySuggestionBatch = {
+        date,
+        generatedAt: new Date().toISOString(),
+        items: generated.items,
+      };
+      try {
+        await put(pathname, JSON.stringify(batch), {
+          access: 'public',
+          addRandomSuffix: false,
+          allowOverwrite: false,
+          contentType: 'application/json',
+          cacheControlMaxAge: 2_678_400,
+        });
+        logAttempt(date, attempts, 'stored');
+        return void res.status(200).json({ status: 'created', date, attempts });
+      } catch {
+        logAttempt(date, attempts, 'store_failed');
+        if (await exists(pathname)) {
+          return void res.status(200).json({ status: 'exists', date, attempts });
+        }
+        return void res.status(502).json({ error: 'Failed to store daily suggestions', date });
+      }
+    }
+    res.status(502).json({ error: 'Failed to generate valid daily suggestions', date });
+  } finally {
+    await releaseClaim(claim);
+  }
 }

--- a/api/daily-suggestions-generate.ts
+++ b/api/daily-suggestions-generate.ts
@@ -73,10 +73,11 @@ async function generateItems(apiKey: string) {
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'GET') return void res.status(405).json({ error: 'Method not allowed' });
-  if (req.headers.authorization !== `Bearer ${process.env.CRON_SECRET}`) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret || req.headers.authorization !== `Bearer ${cronSecret}`) {
     return void res.status(401).json({ error: 'Unauthorized' });
   }
-  const apiKey = process.env.OFFICIAL_API_KEY || process.env.VITE_API_KEY || '';
+  const apiKey = process.env.OFFICIAL_API_KEY || '';
   if (!apiKey) return void res.status(500).json({ error: 'Official API key is not configured' });
 
   const date = tomorrowInBeijing();

--- a/api/daily-suggestions-generate.ts
+++ b/api/daily-suggestions-generate.ts
@@ -10,6 +10,7 @@ import {
 const UPSTREAM = 'https://api.deepseek.com/v1/chat/completions';
 const MODEL = 'deepseek-v4-pro';
 const LOCK_STALE_MS = 5 * 60 * 1000;
+const CLAIM_BACKOFF_MS = [100, 200, 400] as const;
 
 const DAILY_SUGGESTION_SYSTEM_PROMPT = `# Goal
 Create a fresh daily batch of entry suggestions that users can send directly to an AI music-making agent.
@@ -97,6 +98,7 @@ type ClaimResult =
 async function claimDate(date: string, finalPath: string): Promise<ClaimResult> {
   const pathname = lockPath(date);
   for (let claimAttempt = 0; claimAttempt < 2; claimAttempt += 1) {
+    if (await exists(finalPath)) return { status: 'exists' };
     try {
       const lock = await put(pathname, JSON.stringify({ date, claimedAt: new Date().toISOString() }), {
         access: 'public',
@@ -122,6 +124,20 @@ async function claimDate(date: string, finalPath: string): Promise<ClaimResult> 
   return { status: 'in-progress' };
 }
 
+async function wait(milliseconds: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function waitForClaim(date: string, finalPath: string): Promise<ClaimResult> {
+  let claim = await claimDate(date, finalPath);
+  for (const backoff of CLAIM_BACKOFF_MS) {
+    if (claim.status !== 'in-progress') return claim;
+    await wait(backoff);
+    claim = await claimDate(date, finalPath);
+  }
+  return claim;
+}
+
 async function releaseClaim(claim: Extract<ClaimResult, { status: 'acquired' }>) {
   try {
     await del(claim.pathname, { ifMatch: claim.etag });
@@ -145,14 +161,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   const date = tomorrowInBeijing();
   const pathname = dailySuggestionPath(date);
-  if (await exists(pathname)) return void res.status(200).json({ status: 'exists', date, attempts: 0 });
-
-  const claim = await claimDate(date, pathname);
+  const claim = await waitForClaim(date, pathname);
   if (claim.status === 'exists') {
     return void res.status(200).json({ status: 'exists', date, attempts: 0 });
   }
   if (claim.status === 'in-progress') {
-    return void res.status(202).json({ status: 'in-progress', date, attempts: 0 });
+    return void res.status(503).json({ error: 'Daily suggestion generation is still in progress', date });
   }
 
   try {

--- a/api/daily-suggestions-generate.ts
+++ b/api/daily-suggestions-generate.ts
@@ -29,7 +29,7 @@ Return 10 objects. Mix accessible ideas with a few specific electronic-music or 
 # Constraints
 - Output strict JSON only in this shape: {"items":[{"zh":"...","en":"..."}]}.
 - Include exactly 10 items.
-- Chinese values must be 8-80 characters; English values must be 16-180 characters.
+- Chinese values must be 8-24 characters; English values must be 16-70 characters, so each fits on one compact suggestion chip without overflowing.
 - Do not use Markdown, list prefixes, numbering, or commentary.
 - Do not repeat or lightly paraphrase an item within either language.
 

--- a/api/daily-suggestions-generate.ts
+++ b/api/daily-suggestions-generate.ts
@@ -1,0 +1,103 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { head, put } from '@vercel/blob';
+import {
+  dailySuggestionPath,
+  parseGeneratedItems,
+  tomorrowInBeijing,
+  type DailySuggestionBatch,
+} from './daily-suggestions-core';
+
+const UPSTREAM = 'https://api.deepseek.com/v1/chat/completions';
+const MODEL = 'deepseek-v4-pro';
+
+const DAILY_SUGGESTION_SYSTEM_PROMPT = `# Goal
+Create a fresh daily batch of entry suggestions that users can send directly to an AI music-making agent.
+
+# Principles
+- Sound like a real person describing music they want, not a command menu.
+- Make the batch varied, vivid, and musically actionable.
+- Keep each Chinese and English value aligned to the same creative intent.
+
+# Knowledge
+Useful directions include mood, imagined scene, rhythm or onomatopoeia, genre, instrumentation, arrangement, tempo, and production texture. Cover several different directions instead of repeating one template.
+
+# Guidance
+Return 10 objects. Mix accessible ideas with a few specific electronic-music or arrangement ideas. Prefer concrete sensory language over generic requests such as "make good music".
+
+# Constraints
+- Output strict JSON only in this shape: {"items":[{"zh":"...","en":"..."}]}.
+- Include exactly 10 items.
+- Chinese values must be 8-80 characters; English values must be 16-180 characters.
+- Do not use Markdown, list prefixes, numbering, or commentary.
+- Do not repeat or lightly paraphrase an item within either language.
+
+# Review
+Before responding, verify the JSON shape, count, bilingual intent alignment, length limits, diversity, and uniqueness.`;
+
+async function exists(pathname: string): Promise<boolean> {
+  try {
+    await head(pathname);
+    return true;
+  } catch (error) {
+    if (error instanceof Error && error.name === 'BlobNotFoundError') return false;
+    throw error;
+  }
+}
+
+async function generateItems(apiKey: string) {
+  const response = await fetch(UPSTREAM, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      model: MODEL,
+      stream: false,
+      temperature: 1,
+      max_tokens: 1800,
+      response_format: { type: 'json_object' },
+      messages: [
+        { role: 'system', content: DAILY_SUGGESTION_SYSTEM_PROMPT },
+        { role: 'user', content: 'Generate today\'s 10 bilingual entry suggestions.' },
+      ],
+    }),
+  });
+  if (!response.ok) throw new Error(`Model request failed: ${response.status}`);
+  const json = await response.json() as { choices?: Array<{ message?: { content?: string } }> };
+  const content = json.choices?.[0]?.message?.content;
+  if (!content) return null;
+  try {
+    return parseGeneratedItems(JSON.parse(content));
+  } catch {
+    return null;
+  }
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'GET') return void res.status(405).json({ error: 'Method not allowed' });
+  if (req.headers.authorization !== `Bearer ${process.env.CRON_SECRET}`) {
+    return void res.status(401).json({ error: 'Unauthorized' });
+  }
+  const apiKey = process.env.OFFICIAL_API_KEY || process.env.VITE_API_KEY || '';
+  if (!apiKey) return void res.status(500).json({ error: 'Official API key is not configured' });
+
+  const date = tomorrowInBeijing();
+  const pathname = dailySuggestionPath(date);
+  if (await exists(pathname)) return void res.status(200).json({ status: 'exists', date, attempts: 0 });
+
+  for (let attempts = 1; attempts <= 2; attempts += 1) {
+    const items = await generateItems(apiKey).catch(() => null);
+    if (!items) continue;
+    const batch: DailySuggestionBatch = { date, generatedAt: new Date().toISOString(), items };
+    try {
+      await put(pathname, JSON.stringify(batch), {
+        access: 'public', addRandomSuffix: false, contentType: 'application/json', cacheControlMaxAge: 2_678_400,
+      });
+      console.info('daily_suggestions_generated', { date, pathname, attempts });
+      return void res.status(200).json({ status: 'created', date, attempts });
+    } catch (error) {
+      if (await exists(pathname)) return void res.status(200).json({ status: 'exists', date, attempts });
+      throw error;
+    }
+  }
+  console.error('daily_suggestions_generation_failed', { date });
+  res.status(502).json({ error: 'Failed to generate valid daily suggestions', date });
+}

--- a/api/daily-suggestions.test.ts
+++ b/api/daily-suggestions.test.ts
@@ -75,6 +75,36 @@ describe('daily-suggestions handler', () => {
     expect(res.body).toEqual({ requestedDate: '2026-07-18', sourceDate: '2026-07-18', items });
   });
 
+  it('restarts a pending lookup when Beijing midnight changes the requested date', async () => {
+    vi.setSystemTime('2026-07-17T15:59:59.900Z');
+    let resolveOldFetch!: (response: Response) => void;
+    let resolveNewFetch!: (response: Response) => void;
+    const oldFetch = new Promise<Response>((resolve) => { resolveOldFetch = resolve; });
+    const newFetch = new Promise<Response>((resolve) => { resolveNewFetch = resolve; });
+    vi.mocked(head)
+      .mockResolvedValueOnce({ url: 'https://blob/old-today.json' } as never)
+      .mockResolvedValueOnce({ url: 'https://blob/new-today.json' } as never);
+    vi.stubGlobal('fetch', vi.fn()
+      .mockReturnValueOnce(oldFetch)
+      .mockReturnValueOnce(newFetch));
+    const res = makeRes();
+
+    const pending = handler({ method: 'GET' } as never, res as never);
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(1));
+    vi.setSystemTime('2026-07-17T16:00:00.100Z');
+    resolveOldFetch(new Response(JSON.stringify(batch('2026-07-17')), { status: 200 }));
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(2));
+    vi.setSystemTime('2026-07-18T15:59:59.100Z');
+    resolveNewFetch(new Response(JSON.stringify(batch('2026-07-18')), { status: 200 }));
+    await pending;
+
+    expect(head).toHaveBeenNthCalledWith(1, 'daily-suggestions/2026-07-17.json');
+    expect(head).toHaveBeenNthCalledWith(2, 'daily-suggestions/2026-07-18.json');
+    expect(res.body).toEqual({ requestedDate: '2026-07-18', sourceDate: '2026-07-18', items });
+    expect(res.headers['Cache-Control']).toBe('public, max-age=1');
+    expect(res.headers['Vercel-CDN-Cache-Control']).toBe('public, max-age=1');
+  });
+
   it('falls through a corrupt today batch to the previous date', async () => {
     vi.mocked(head)
       .mockResolvedValueOnce({ url: 'https://blob/today.json' } as never)

--- a/api/daily-suggestions.test.ts
+++ b/api/daily-suggestions.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { head } from '@vercel/blob';
+import handler from './daily-suggestions';
+
+vi.mock('@vercel/blob', () => ({ head: vi.fn() }));
+
+const items = Array.from({ length: 10 }, (_, i) => ({
+  zh: `想做一段第${i + 1}种有呼吸感的电子音乐`,
+  en: `I want electronic idea number ${i + 1} with a breathing pulse`,
+}));
+
+function batch(date: string) {
+  return { date, generatedAt: '2026-07-17T15:30:00.000Z', items };
+}
+
+function makeRes() {
+  return {
+    statusCode: 0,
+    body: undefined as unknown,
+    headers: {} as Record<string, string | number | readonly string[]>,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body: unknown) {
+      this.body = body;
+      return this;
+    },
+    setHeader(name: string, value: string | number | readonly string[]) {
+      this.headers[name] = value;
+      return this;
+    },
+  };
+}
+
+describe('daily-suggestions handler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime('2026-07-17T16:30:00.000Z');
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.resetAllMocks();
+  });
+
+  it('falls back from a missing today batch to yesterday', async () => {
+    vi.mocked(head)
+      .mockRejectedValueOnce(new Error('not found'))
+      .mockResolvedValueOnce({ url: 'https://blob/yesterday.json' } as never);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify(batch('2026-07-17')), { status: 200 })));
+    const res = makeRes();
+
+    await handler({ method: 'GET' } as never, res as never);
+
+    expect(head).toHaveBeenNthCalledWith(1, 'daily-suggestions/2026-07-18.json');
+    expect(head).toHaveBeenNthCalledWith(2, 'daily-suggestions/2026-07-17.json');
+    expect(res.body).toMatchObject({ requestedDate: '2026-07-18', sourceDate: '2026-07-17' });
+    expect(res.headers['Vercel-CDN-Cache-Control']).toMatch(/^public, max-age=/);
+    expect(res.headers['Cache-Control']).toBe('public, max-age=300');
+  });
+
+  it('returns a valid today batch without checking older dates', async () => {
+    vi.mocked(head).mockResolvedValue({ url: 'https://blob/today.json' } as never);
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(JSON.stringify(batch('2026-07-18')), { status: 200 })));
+    const res = makeRes();
+
+    await handler({ method: 'GET' } as never, res as never);
+
+    expect(head).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ requestedDate: '2026-07-18', sourceDate: '2026-07-18', items });
+  });
+
+  it('falls through a corrupt today batch to the previous date', async () => {
+    vi.mocked(head)
+      .mockResolvedValueOnce({ url: 'https://blob/today.json' } as never)
+      .mockResolvedValueOnce({ url: 'https://blob/yesterday.json' } as never);
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ...batch('2026-07-18'), items: [] }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(batch('2026-07-17')), { status: 200 })));
+    const res = makeRes();
+
+    await handler({ method: 'GET' } as never, res as never);
+
+    expect(head).toHaveBeenCalledTimes(2);
+    expect(res.body).toMatchObject({ requestedDate: '2026-07-18', sourceDate: '2026-07-17' });
+  });
+
+  it('rejects non-GET requests', async () => {
+    const res = makeRes();
+
+    await handler({ method: 'POST' } as never, res as never);
+
+    expect(res.statusCode).toBe(405);
+    expect(res.body).toEqual({ error: 'Method not allowed' });
+    expect(head).not.toHaveBeenCalled();
+  });
+
+  it('returns a briefly cached 503 after all eight candidates miss', async () => {
+    vi.mocked(head).mockRejectedValue(new Error('not found'));
+    const res = makeRes();
+
+    await handler({ method: 'GET' } as never, res as never);
+
+    expect(head).toHaveBeenCalledTimes(8);
+    expect(head).toHaveBeenLastCalledWith('daily-suggestions/2026-07-11.json');
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toEqual({ error: 'Daily suggestions unavailable', requestedDate: '2026-07-18' });
+    expect(res.headers['Cache-Control']).toBe('public, max-age=60');
+    expect(res.headers['Vercel-CDN-Cache-Control']).toBe('public, max-age=300');
+  });
+});

--- a/api/daily-suggestions.ts
+++ b/api/daily-suggestions.ts
@@ -1,0 +1,45 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { head } from '@vercel/blob';
+import {
+  beijingDate,
+  dailySuggestionPath,
+  parseStoredBatch,
+  readCandidateDates,
+  secondsUntilNextBeijingMidnight,
+} from './daily-suggestions-core';
+
+async function readDate(date: string) {
+  try {
+    const metadata = await head(dailySuggestionPath(date));
+    const response = await fetch(metadata.url);
+    if (!response.ok) return null;
+    return parseStoredBatch(await response.json(), date);
+  } catch {
+    return null;
+  }
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const requestedDate = beijingDate();
+  for (const sourceDate of readCandidateDates(requestedDate)) {
+    const batch = await readDate(sourceDate);
+    if (!batch) continue;
+
+    res.setHeader('Cache-Control', 'public, max-age=300');
+    res.setHeader(
+      'Vercel-CDN-Cache-Control',
+      `public, max-age=${secondsUntilNextBeijingMidnight()}`,
+    );
+    res.status(200).json({ requestedDate, sourceDate, items: batch.items });
+    return;
+  }
+
+  res.setHeader('Cache-Control', 'public, max-age=60');
+  res.setHeader('Vercel-CDN-Cache-Control', 'public, max-age=300');
+  res.status(503).json({ error: 'Daily suggestions unavailable', requestedDate });
+}

--- a/api/daily-suggestions.ts
+++ b/api/daily-suggestions.ts
@@ -25,21 +25,32 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return;
   }
 
-  const requestedDate = beijingDate();
-  for (const sourceDate of readCandidateDates(requestedDate)) {
-    const batch = await readDate(sourceDate);
-    if (!batch) continue;
+  while (true) {
+    const requestedDate = beijingDate();
+    let dateChanged = false;
+    for (const sourceDate of readCandidateDates(requestedDate)) {
+      const batch = await readDate(sourceDate);
+      const responseNow = new Date();
+      if (beijingDate(responseNow) !== requestedDate) {
+        dateChanged = true;
+        break;
+      }
+      if (!batch) continue;
 
-    res.setHeader('Cache-Control', 'public, max-age=300');
-    res.setHeader(
-      'Vercel-CDN-Cache-Control',
-      `public, max-age=${secondsUntilNextBeijingMidnight()}`,
-    );
-    res.status(200).json({ requestedDate, sourceDate, items: batch.items });
+      const midnightTtl = secondsUntilNextBeijingMidnight(responseNow);
+      res.setHeader('Cache-Control', `public, max-age=${Math.min(300, midnightTtl)}`);
+      res.setHeader('Vercel-CDN-Cache-Control', `public, max-age=${midnightTtl}`);
+      res.status(200).json({ requestedDate, sourceDate, items: batch.items });
+      return;
+    }
+    if (dateChanged) continue;
+
+    const responseNow = new Date();
+    if (beijingDate(responseNow) !== requestedDate) continue;
+    const midnightTtl = secondsUntilNextBeijingMidnight(responseNow);
+    res.setHeader('Cache-Control', `public, max-age=${Math.min(60, midnightTtl)}`);
+    res.setHeader('Vercel-CDN-Cache-Control', `public, max-age=${Math.min(300, midnightTtl)}`);
+    res.status(503).json({ error: 'Daily suggestions unavailable', requestedDate });
     return;
   }
-
-  res.setHeader('Cache-Control', 'public, max-age=60');
-  res.setHeader('Vercel-CDN-Cache-Control', 'public, max-age=300');
-  res.status(503).json({ error: 'Daily suggestions unavailable', requestedDate });
 }

--- a/docs/superpowers/specs/2026-07-16-daily-entry-suggestions-design.md
+++ b/docs/superpowers/specs/2026-07-16-daily-entry-suggestions-design.md
@@ -76,10 +76,15 @@ The server accepts a batch only when:
 
 - it contains exactly 10 objects;
 - every object has non-empty `zh` and `en` strings;
-- values fit configured length limits;
 - neither language contains duplicate normalized values;
 - values do not contain list numbering, Markdown fences, or surrounding commentary;
 - the payload date matches the date being generated.
+
+Length is guided by the generation prompt (Chinese 8-24, English 16-70
+characters, sized to fit one suggestion chip) but is **not** validated. An
+occasional over-length item degrades chip display without discarding an
+otherwise valid daily batch; enforcing length in code would throw away the
+whole batch and fall back to a stale day instead.
 
 Validation is implemented as pure functions so malformed model output cannot be published. If both generation attempts fail, the endpoint reports failure and leaves all existing batches untouched.
 

--- a/docs/superpowers/specs/2026-07-16-daily-entry-suggestions-design.md
+++ b/docs/superpowers/specs/2026-07-16-daily-entry-suggestions-design.md
@@ -1,0 +1,163 @@
+# Daily Entry Suggestions Design
+
+## Goal
+
+Replace the fixed entry suggestion pool with one AI-generated bilingual batch per day while keeping the page fast, the feature safe on Vercel Hobby limits, and the existing agent-generated next-step suggestions unchanged.
+
+## Product behavior
+
+- One batch is shared by all users worldwide.
+- Each batch contains exactly 10 Chinese/English suggestion pairs.
+- The client selects 5 suggestions from the active language for display.
+- A day is defined by `Asia/Shanghai` time.
+- A page fetches the daily batch when it loads. A page that remains open across midnight does not refresh automatically; it updates on the next reload or visit.
+- Daily suggestions only replace the static defaults shown before a user has started creating. Persisted suggestions and next-step suggestions emitted by the agent keep their existing precedence.
+
+## Architecture
+
+### Daily generation
+
+A new Vercel Cron endpoint generates the next day's batch. Because Vercel Hobby schedules daily jobs with hourly rather than minute-level precision, the job runs during 23:00-23:59 Beijing time and writes a batch dated for the following day. This makes the next batch available before the client switches dates at midnight.
+
+The endpoint:
+
+1. Requires the existing `CRON_SECRET` bearer token.
+2. Computes tomorrow's date in `Asia/Shanghai`.
+3. Returns successfully without another model call if that date already exists, making retries idempotent.
+4. Calls the existing official server-side model provider using the server-held API key.
+5. Parses and validates strict JSON.
+6. Retries generation once when the response is malformed or invalid.
+7. Writes the validated result to an immutable dated Blob.
+
+The job never overwrites a previously valid dated batch.
+
+### Blob format
+
+The pathname is deterministic:
+
+```text
+daily-suggestions/YYYY-MM-DD.json
+```
+
+The stored payload is:
+
+```json
+{
+  "date": "2026-07-18",
+  "generatedAt": "2026-07-17T15:23:00.000Z",
+  "items": [
+    {
+      "zh": "想做一段雨停以后慢慢放晴的电子乐",
+      "en": "I want an electronic track that slowly clears up after the rain"
+    }
+  ]
+}
+```
+
+`items` contains exactly 10 entries. Dated immutable objects avoid stale browser/CDN content and remove the need for a mutable `latest.json` pointer.
+
+### Public read endpoint
+
+A public, read-only endpoint returns the batch for the current Beijing date. It looks up deterministic dated paths rather than calling Blob `list()` on every page visit.
+
+Lookup order:
+
+1. Today's dated Blob.
+2. Up to the previous 7 dates, newest first.
+3. An unavailable response that tells the client to retain its bundled static defaults.
+
+The response includes both the requested date and the actual source date so stale fallback usage is observable. Its CDN caching expires at the next Beijing midnight. This keeps Blob reads and Function origin executions small even when many users load the page.
+
+## Generation prompt and validation
+
+The model is asked for natural user messages that can be sent directly to the music agent. The 10 entries should be diverse across mood, scene, rhythm, genre, instrumentation, arrangement, and onomatopoeic ideas. Chinese and English values must carry the same intent rather than being unrelated lists.
+
+The server accepts a batch only when:
+
+- it contains exactly 10 objects;
+- every object has non-empty `zh` and `en` strings;
+- values fit configured length limits;
+- neither language contains duplicate normalized values;
+- values do not contain list numbering, Markdown fences, or surrounding commentary;
+- the payload date matches the date being generated.
+
+Validation is implemented as pure functions so malformed model output cannot be published. If both generation attempts fail, the endpoint reports failure and leaves all existing batches untouched.
+
+## Client data flow
+
+The bundled static bilingual suggestions remain as the immediate and final fallback. Page load proceeds as follows:
+
+1. Render immediately using the bundled static pool.
+2. Fetch the daily suggestion endpoint in the background.
+3. Validate the response shape defensively.
+4. Select the current interface language from each bilingual pair.
+5. Randomly choose up to 5 items and replace only the active default suggestion source.
+
+The suggestion hook must distinguish default suggestions from persisted or newly committed next-step suggestions. Resolving the daily request must not overwrite:
+
+- suggestions restored for the current code;
+- suggestions emitted by the latest agent commit;
+- suggestions for another session after a session switch.
+
+When the user switches to an empty session after the daily batch has loaded, the hook may draw a fresh set of 5 from the same daily batch.
+
+Network, Blob, parsing, or validation failures are silent from the user's perspective: the input remains usable and continues showing bundled defaults.
+
+## Retention and cleanup
+
+The existing `/api/cleanup` Cron handler is extended instead of adding another cleanup job. Its current share cleanup and the new daily-suggestion cleanup remain isolated so failure in one does not prevent the other from running.
+
+Daily-suggestion cleanup:
+
+- lists only the `daily-suggestions/` prefix;
+- parses the date from each expected pathname;
+- retains the latest 30 days;
+- deletes older objects;
+- ignores unexpected pathnames and records them for diagnosis rather than deleting them blindly.
+
+The runtime read path searches only the latest 7 dates. The additional retained history exists for generation-quality review and incident diagnosis. One daily prefix listing adds roughly 30 advanced Blob operations per month; Blob deletion is not billed.
+
+## Security and operations
+
+- Only the generation endpoint can call the model and write data, and it requires `CRON_SECRET`.
+- Provider and Blob credentials remain server-side.
+- The read endpoint is public and read-only.
+- Logs record the target date, generation attempt count, validation outcome, stored pathname, fallback source date, and cleanup counts without logging credentials.
+- A failed generation preserves yesterday's content through the 7-day read fallback.
+
+## Testing
+
+### Unit tests
+
+- Beijing current-date and next-date calculations around UTC day boundaries.
+- Valid batches and each schema rejection case.
+- Normalized duplicate detection in both languages.
+- Retention cutoff and safe pathname parsing.
+- Random selection returns at most 5 unique suggestions.
+
+### API tests
+
+- Generation rejects missing or invalid Cron authorization.
+- An existing target date makes generation idempotent.
+- A valid model response is written once.
+- Invalid output retries once and never writes invalid data.
+- The read endpoint returns today's batch, then recent fallback, then unavailable.
+- Read responses expose the source date and correct cache headers.
+- Cleanup keeps 30 days, deletes older dated objects, and leaves unexpected objects untouched.
+
+### Hook tests
+
+- Bundled defaults render before the request resolves.
+- A valid daily batch replaces only default suggestions.
+- Persisted suggestions matching current code take precedence.
+- New commit suggestions take precedence and remain persisted.
+- A late daily response does not overwrite another session or agent suggestions.
+- Fetch and response-validation failures retain bundled defaults.
+
+## Out of scope
+
+- Per-user generation or personalization.
+- An editorial review or administration interface.
+- Automatic refresh for a page left open across midnight.
+- More than one model generation call per day, aside from the single invalid-output retry.
+- Backfilling missing historical dates.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import VizPlaceholder from './components/VizPlaceholder';
 import { useStrudel } from './hooks/useStrudel';
 import { useSessions } from './hooks/useSessions';
 import { useSuggestions } from './hooks/useSuggestions';
+import { useDailySuggestions } from './hooks/useDailySuggestions';
 import { fetchMoodContext } from './services/airjelly';
 import { generateSongTitle } from './services/song-title';
 import type { ConversationTurn, ProgressEvent } from './services/llm';
@@ -36,6 +37,7 @@ export default function App() {
     (code) => { strudel.play(code); }
   );
   const sessions = useSessions();
+  const dailySuggestionDefaults = useDailySuggestions(zh);
   const importStatus = useImportShare(sessions.importSession, !sessions.isLoading);
   const [loadingSessions, setLoadingSessions] = useState<Set<string>>(new Set());
   const [commitSuggestions, setCommitSuggestions] = useState<string[] | null>(null);
@@ -144,6 +146,7 @@ export default function App() {
   const { suggestions } = useSuggestions({
     key: current?.id ?? '',
     currentCode: current?.code ?? '',
+    defaults: dailySuggestionDefaults,
     commitSuggestions: commitSuggestions ?? undefined,
     persisted: current?.suggestions,
     onSuggestions: (items, forCode) => sessions.setSuggestions(items, forCode, current?.id),

--- a/src/hooks/__tests__/useDailySuggestions.test.tsx
+++ b/src/hooks/__tests__/useDailySuggestions.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../services/daily-suggestions', () => ({
+  fetchDailySuggestions: vi.fn(),
+}));
+
+import { fetchDailySuggestions } from '../../services/daily-suggestions';
+import { useDailySuggestions } from '../useDailySuggestions';
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+
+const fetchDailySuggestionsMock = vi.mocked(fetchDailySuggestions);
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+function Probe({
+  isChinese,
+  onValue,
+}: {
+  isChinese: boolean;
+  onValue: (value: ReturnType<typeof useDailySuggestions>) => void;
+}) {
+  onValue(useDailySuggestions(isChinese));
+  return null;
+}
+
+function renderProbe(
+  isChinese: boolean,
+  onValue: (value: ReturnType<typeof useDailySuggestions>) => void,
+) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(<Probe isChinese={isChinese} onValue={onValue} />);
+  });
+  return {
+    root,
+    rerender(nextIsChinese = isChinese) {
+      act(() => {
+        root.render(<Probe isChinese={nextIsChinese} onValue={onValue} />);
+      });
+    },
+  };
+}
+
+describe('useDailySuggestions', () => {
+  const roots: Root[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) {
+      act(() => root.unmount());
+    }
+    document.body.innerHTML = '';
+    vi.clearAllMocks();
+  });
+
+  it('starts undefined, resolves to the fetched pool, and fetches once per mount', async () => {
+    const request = deferred<string[] | null>();
+    const pool = Array.from({ length: 10 }, (_, index) => `suggestion ${index}`);
+    fetchDailySuggestionsMock.mockReturnValue(request.promise);
+    let latest: string[] | undefined;
+    const { root, rerender } = renderProbe(false, (value) => { latest = value; });
+    roots.push(root);
+
+    expect(latest).toBeUndefined();
+    expect(fetchDailySuggestionsMock).toHaveBeenCalledTimes(1);
+    expect(fetchDailySuggestionsMock).toHaveBeenCalledWith(false, expect.any(AbortSignal));
+
+    rerender();
+    expect(fetchDailySuggestionsMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => request.resolve(pool));
+
+    expect(latest).toBe(pool);
+  });
+
+  it('remains undefined when the service returns null', async () => {
+    fetchDailySuggestionsMock.mockResolvedValue(null);
+    let latest: string[] | undefined;
+    const { root } = renderProbe(true, (value) => { latest = value; });
+    roots.push(root);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(latest).toBeUndefined();
+  });
+
+  it('aborts on unmount and ignores a late result', async () => {
+    const request = deferred<string[] | null>();
+    fetchDailySuggestionsMock.mockReturnValue(request.promise);
+    const onValue = vi.fn();
+    const { root } = renderProbe(false, onValue);
+    const signal = fetchDailySuggestionsMock.mock.calls[0][1];
+    const renderCount = onValue.mock.calls.length;
+
+    act(() => root.unmount());
+
+    expect(signal?.aborted).toBe(true);
+    await act(async () => request.resolve(['late suggestion']));
+    expect(onValue).toHaveBeenCalledTimes(renderCount);
+  });
+});

--- a/src/hooks/__tests__/useSuggestions.test.tsx
+++ b/src/hooks/__tests__/useSuggestions.test.tsx
@@ -14,11 +14,12 @@ import { useSuggestions } from '../useSuggestions';
 Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
 
 function Probe({
+  props,
   onValue,
-  ...props
-}: Partial<Parameters<typeof useSuggestions>[0]> & {
+}: {
+  props: Partial<Parameters<typeof useSuggestions>[0]>;
   onValue?: (value: ReturnType<typeof useSuggestions>) => void;
-} = {}) {
+}) {
   const value = useSuggestions({
     key: props.key ?? 'session-1',
     currentCode: props.currentCode ?? 's("bd")',
@@ -36,10 +37,28 @@ function renderProbe(
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
-  act(() => {
-    root.render(<Probe {...props} />);
-  });
-  return { root };
+  let latest: ReturnType<typeof useSuggestions> | undefined;
+
+  const render = (next: typeof props) => {
+    act(() => {
+      root.render(
+        <Probe
+          props={next}
+          onValue={(value) => {
+            latest = value;
+            next.onValue?.(value);
+          }}
+        />,
+      );
+    });
+  };
+
+  render(props);
+  return {
+    root,
+    latest: () => latest,
+    rerender: render,
+  };
 }
 
 describe('useSuggestions', () => {
@@ -117,5 +136,51 @@ describe('useSuggestions', () => {
 
     expect(latest?.suggestions).toEqual(['一', '二', '三', '四', '五']);
     expect(onSuggestions).toHaveBeenCalledWith(['一', '二', '三', '四', '五'], 's("bd sd")');
+  });
+
+  it('replaces only bundled defaults when daily defaults arrive late', () => {
+    const view = renderProbe({ defaults: undefined, currentCode: '' });
+    roots.push(view.root);
+
+    view.rerender({ defaults: ['daily 1', 'daily 2'], currentCode: '' });
+
+    expect(view.latest()?.suggestions).toEqual(expect.arrayContaining(['daily 1', 'daily 2']));
+  });
+
+  it('does not replace restored suggestions when daily defaults arrive', () => {
+    const persisted = { forCode: 's("bd")', items: ['继续加贝斯'] };
+    const view = renderProbe({ currentCode: 's("bd")', persisted });
+    roots.push(view.root);
+
+    view.rerender({ currentCode: 's("bd")', persisted, defaults: ['daily 1'] });
+
+    expect(view.latest()?.suggestions).toEqual(['继续加贝斯']);
+  });
+
+  it('does not replace commit suggestions when daily defaults arrive', () => {
+    const view = renderProbe({ currentCode: 's("bd")', commitSuggestions: ['把鼓切碎'] });
+    roots.push(view.root);
+
+    view.rerender({
+      currentCode: 's("bd")',
+      commitSuggestions: ['把鼓切碎'],
+      defaults: ['daily 1'],
+    });
+
+    expect(view.latest()?.suggestions).toEqual(['把鼓切碎']);
+  });
+
+  it('uses the loaded daily pool after switching to an empty session', () => {
+    const view = renderProbe({
+      key: 'one',
+      currentCode: 's("bd")',
+      persisted: { forCode: 's("bd")', items: ['继续'] },
+      defaults: ['daily 1', 'daily 2'],
+    });
+    roots.push(view.root);
+
+    view.rerender({ key: 'two', currentCode: '', defaults: ['daily 1', 'daily 2'] });
+
+    expect(view.latest()?.suggestions).toEqual(expect.arrayContaining(['daily 1', 'daily 2']));
   });
 });

--- a/src/hooks/useDailySuggestions.ts
+++ b/src/hooks/useDailySuggestions.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+import { fetchDailySuggestions } from '../services/daily-suggestions';
+
+export function useDailySuggestions(isChinese: boolean): string[] | undefined {
+  const [items, setItems] = useState<string[]>();
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetchDailySuggestions(isChinese, controller.signal).then((next) => {
+      if (next && !controller.signal.aborted) {
+        setItems(next);
+      }
+    });
+
+    return () => controller.abort();
+  }, [isChinese]);
+
+  return items;
+}

--- a/src/hooks/useSuggestions.ts
+++ b/src/hooks/useSuggestions.ts
@@ -1,16 +1,15 @@
 import { useEffect, useRef, useState } from 'react';
+import { pickSuggestions } from '../services/daily-suggestions';
 import { STATIC_SUGGESTIONS } from '../services/suggestions';
 
 type Persisted = { forCode: string; items: string[] };
+type SuggestionSource = 'default' | 'persisted' | 'commit';
+type SuggestionState = { source: SuggestionSource; items: string[] };
 
 // Upper bound on how many suggestions the hook exposes. Desktop rotates through
 // all of them as placeholder chips; the mobile layout slices this down to two
 // quick-action buttons at its render site.
 const MAX_SUGGESTIONS = 5;
-
-function randomStatic(): string[] {
-  return [...STATIC_SUGGESTIONS].sort(() => Math.random() - 0.5).slice(0, MAX_SUGGESTIONS);
-}
 
 // Persisted chips are only usable when they were generated for the code we're
 // showing now; otherwise they're stale (commit writes code, then produces
@@ -20,6 +19,22 @@ function restoredFor(persisted: Persisted | undefined, currentCode: string): str
     return persisted.items.slice(0, MAX_SUGGESTIONS);
   }
   return null;
+}
+
+function defaultState(defaults?: string[]): SuggestionState {
+  return {
+    source: 'default',
+    items: pickSuggestions(defaults?.length ? defaults : STATIC_SUGGESTIONS, MAX_SUGGESTIONS),
+  };
+}
+
+function initialState(
+  persisted: Persisted | undefined,
+  currentCode: string,
+  defaults?: string[],
+): SuggestionState {
+  const restored = restoredFor(persisted, currentCode);
+  return restored ? { source: 'persisted', items: restored } : defaultState(defaults);
 }
 
 /**
@@ -41,6 +56,8 @@ function restoredFor(persisted: Persisted | undefined, currentCode: string): str
 export function useSuggestions(opts: {
   key: string;
   currentCode: string;
+  /** The daily entry suggestion pool, when available. */
+  defaults?: string[];
   /** The next-step options from the latest commit explanation (up to MAX_SUGGESTIONS). */
   commitSuggestions?: string[];
   /** Suggestions persisted on the session from a previous page load. */
@@ -48,12 +65,13 @@ export function useSuggestions(opts: {
   /** Called with fresh suggestions + the code they were generated for, so the caller can persist them. */
   onSuggestions?: (items: string[], forCode: string) => void;
 }) {
-  const { key, currentCode, commitSuggestions, persisted, onSuggestions } = opts;
-  const [suggestions, setSuggestions] = useState<string[]>(
-    () => restoredFor(persisted, currentCode) ?? randomStatic(),
+  const { key, currentCode, defaults, commitSuggestions, persisted, onSuggestions } = opts;
+  const [state, setState] = useState<SuggestionState>(
+    () => initialState(persisted, currentCode, defaults),
   );
   const [prevCommit, setPrevCommit] = useState<string[] | undefined>(undefined);
   const [prevKey, setPrevKey] = useState(key);
+  const [prevDefaults, setPrevDefaults] = useState(defaults);
   // Read the freshest currentCode / onSuggestions inside the persist effect
   // without adding them to its deps (they'd re-fire it on every render).
   const currentCodeRef = useRef(currentCode);
@@ -66,8 +84,8 @@ export function useSuggestions(opts: {
   // Show the latest commit's next-step options as soon as they arrive.
   if (prevCommit !== commitSuggestions) {
     setPrevCommit(commitSuggestions);
-    if (commitSuggestions && commitSuggestions.length > 0) {
-      setSuggestions(commitSuggestions.slice(0, MAX_SUGGESTIONS));
+    if (commitSuggestions?.length) {
+      setState({ source: 'commit', items: commitSuggestions.slice(0, MAX_SUGGESTIONS) });
     }
   }
 
@@ -76,7 +94,14 @@ export function useSuggestions(opts: {
   // commit block so a session switch wins over stale commit chips.
   if (prevKey !== key) {
     setPrevKey(key);
-    setSuggestions(restoredFor(persisted, currentCode) ?? randomStatic());
+    setState(initialState(persisted, currentCode, defaults));
+  }
+
+  // A late daily response may replace bundled defaults, but never suggestions
+  // restored for code or emitted by an agent commit.
+  if (prevDefaults !== defaults) {
+    setPrevDefaults(defaults);
+    setState((current) => current.source === 'default' ? defaultState(defaults) : current);
   }
 
   // Persist freshly shown commit chips to the session (external system sync).
@@ -85,5 +110,5 @@ export function useSuggestions(opts: {
     onSuggestionsRef.current?.(commitSuggestions.slice(0, MAX_SUGGESTIONS), currentCodeRef.current);
   }, [commitSuggestions]);
 
-  return { suggestions };
+  return { suggestions: state.items };
 }

--- a/src/services/__tests__/daily-suggestions.test.ts
+++ b/src/services/__tests__/daily-suggestions.test.ts
@@ -86,4 +86,16 @@ describe('pickSuggestions', () => {
   it('returns all available unique values when the limit exceeds the pool', () => {
     expect(pickSuggestions(['one', 'one', 'two'], 5, () => 0)).toHaveLength(2);
   });
+
+  it('enforces the global maximum when the requested limit exceeds five', () => {
+    const pool = Array.from({ length: 10 }, (_, index) => String(index));
+
+    expect(pickSuggestions(pool, 10, () => 0)).toHaveLength(5);
+  });
+
+  it('returns no values when the requested limit is negative', () => {
+    const pool = Array.from({ length: 10 }, (_, index) => String(index));
+
+    expect(pickSuggestions(pool, -2, () => 0)).toEqual([]);
+  });
 });

--- a/src/services/__tests__/daily-suggestions.test.ts
+++ b/src/services/__tests__/daily-suggestions.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchDailySuggestions, pickSuggestions } from '../daily-suggestions';
+
+const items = Array.from({ length: 10 }, (_, index) => ({
+  zh: ` 中文提示${index} `,
+  en: ` English suggestion ${index} `,
+}));
+
+describe('fetchDailySuggestions', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('projects a valid daily batch into the active language', async () => {
+    const fetchMock = vi.fn().mockImplementation(async () => new Response(JSON.stringify({
+      requestedDate: '2026-07-18',
+      sourceDate: '2026-07-18',
+      items,
+    }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(fetchDailySuggestions(true)).resolves.toEqual(
+      items.map((item) => item.zh.trim()),
+    );
+    await expect(fetchDailySuggestions(false)).resolves.toEqual(
+      items.map((item) => item.en.trim()),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/api/daily-suggestions', { signal: undefined });
+  });
+
+  it.each([
+    ['a non-OK response', new Response('unavailable', { status: 503 })],
+    ['a payload without dates', new Response(JSON.stringify({ items }), { status: 200 })],
+    ['a payload without exactly ten items', new Response(JSON.stringify({
+      requestedDate: '2026-07-18',
+      sourceDate: '2026-07-18',
+      items: items.slice(0, 9),
+    }), { status: 200 })],
+    ['a payload with an empty translation', new Response(JSON.stringify({
+      requestedDate: '2026-07-18',
+      sourceDate: '2026-07-18',
+      items: [{ zh: ' ', en: 'missing' }, ...items.slice(1)],
+    }), { status: 200 })],
+  ])('returns null for %s', async (_label, response) => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response));
+
+    await expect(fetchDailySuggestions(true)).resolves.toBeNull();
+  });
+
+  it('returns null when the request or JSON parsing fails', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network error')));
+    await expect(fetchDailySuggestions(true)).resolves.toBeNull();
+
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('not json', { status: 200 })));
+    await expect(fetchDailySuggestions(true)).resolves.toBeNull();
+  });
+
+  it('passes the abort signal to fetch', async () => {
+    const controller = new AbortController();
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      requestedDate: '2026-07-18',
+      sourceDate: '2026-07-18',
+      items,
+    }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchDailySuggestions(true, controller.signal);
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/daily-suggestions', { signal: controller.signal });
+  });
+});
+
+describe('pickSuggestions', () => {
+  it('selects at most five unique values without mutating the pool', () => {
+    const pool = ['0', '1', '2', '2', '3', '4', '5', '6', '7', '8', '9'];
+    const original = [...pool];
+
+    const selected = pickSuggestions(pool, 5, () => 0.5);
+
+    expect(selected).toHaveLength(5);
+    expect(new Set(selected)).toHaveLength(5);
+    expect(selected.every((value) => pool.includes(value))).toBe(true);
+    expect(pool).toEqual(original);
+  });
+
+  it('returns all available unique values when the limit exceeds the pool', () => {
+    expect(pickSuggestions(['one', 'one', 'two'], 5, () => 0)).toHaveLength(2);
+  });
+});

--- a/src/services/daily-suggestions.ts
+++ b/src/services/daily-suggestions.ts
@@ -52,5 +52,5 @@ export function pickSuggestions(
     const swap = Math.floor(random() * (index + 1));
     [copy[index], copy[swap]] = [copy[swap], copy[index]];
   }
-  return copy.slice(0, limit);
+  return copy.slice(0, Math.min(5, Math.max(0, limit)));
 }

--- a/src/services/daily-suggestions.ts
+++ b/src/services/daily-suggestions.ts
@@ -1,0 +1,56 @@
+interface DailyResponse {
+  requestedDate: string;
+  sourceDate: string;
+  items: Array<{ zh: string; en: string }>;
+}
+
+function parseResponse(value: unknown): DailyResponse | null {
+  if (!value || typeof value !== 'object') return null;
+
+  const candidate = value as Partial<DailyResponse>;
+  if (typeof candidate.requestedDate !== 'string' || typeof candidate.sourceDate !== 'string') {
+    return null;
+  }
+  if (!Array.isArray(candidate.items) || candidate.items.length !== 10) return null;
+  if (!candidate.items.every((item) => (
+    item
+    && typeof item.zh === 'string'
+    && item.zh.trim()
+    && typeof item.en === 'string'
+    && item.en.trim()
+  ))) {
+    return null;
+  }
+
+  return candidate as DailyResponse;
+}
+
+export async function fetchDailySuggestions(
+  isChinese: boolean,
+  signal?: AbortSignal,
+): Promise<string[] | null> {
+  try {
+    const response = await fetch('/api/daily-suggestions', { signal });
+    if (!response.ok) return null;
+
+    const parsed = parseResponse(await response.json());
+    return parsed
+      ? parsed.items.map((item) => (isChinese ? item.zh : item.en).trim())
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function pickSuggestions(
+  pool: readonly string[],
+  limit = 5,
+  random = Math.random,
+): string[] {
+  const copy = [...new Set(pool.filter(Boolean))];
+  for (let index = copy.length - 1; index > 0; index -= 1) {
+    const swap = Math.floor(random() * (index + 1));
+    [copy[index], copy[swap]] = [copy[swap], copy[index]];
+  }
+  return copy.slice(0, limit);
+}

--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,8 @@
     {"source": "/s/:id", "destination": "/api/share-page?id=:id"},
     {"source": "/(.*)", "destination": "/index.html"}
   ],
-  "crons": [{"path": "/api/cleanup", "schedule": "0 0 * * *"}]
+  "crons": [
+    {"path": "/api/cleanup", "schedule": "0 0 * * *"},
+    {"path": "/api/daily-suggestions-generate", "schedule": "0 15 * * *"}
+  ]
 }


### PR DESCRIPTION
每天由 AI 生成一批双语入口建议，替换固定的静态建议池。

设计文档：`docs/superpowers/specs/2026-07-16-daily-entry-suggestions-design.md`

## 结构

- **生成端** `/api/daily-suggestions-generate` — Vercel Cron 每天 15:00 UTC（北京 23:00）触发，`CRON_SECRET` 鉴权，生成 10 条中英对照，写入 Blob 的 `daily-suggestions/YYYY-MM-DD.json`。写的是**明天**的日期，让客户端跨过午夜时批次已就绪。Blob 不可覆盖，重试幂等；输出非法时重试一次，两次都失败则不写入任何数据。
- **读取端** `/api/daily-suggestions` — 公开只读，按北京日期查当天，未命中则回溯 7 天，再未命中返回 503。响应带 `sourceDate`，便于观察是否在吃回退数据。CDN 缓存在北京午夜到期。
- **客户端** `useDailySuggestions` → 随机取 5 条，**只**替换默认建议。已持久化的建议、agent 最新提交的建议、以及切换 session 后的归属，优先级都不受影响。任何网络/解析/校验失败对用户静默，输入框继续用打包的静态建议。
- **清理** 复用现有 `/api/cleanup` cron，保留最近 30 天，两个清理任务互相隔离，一个失败不影响另一个。

## 验证

- `npx tsc --noEmit -p tsconfig.app.json` 通过
- `npm test` 全量 42 文件 324 测试通过（本 PR 新增 51 个）
- 与 `main` 自动合并无冲突（`src/App.tsx` 两边改动区域不重叠）

## 部署后待验证

Vercel Cron 不在 preview 触发，且生成端写的是明天的日期、读取端读今天，所以 preview 上需要手动 curl 生成端，界面效果次日可见。合并后第一次真实 cron（北京 23:00）是唯一的遗留验证点，查 Logs 里的 `daily_suggestions_generation_attempt` 结构化日志确认 `outcome: 'stored'`。

⚠️ Vercel Blob store 在 preview 与 production 间共享，且对象不可覆盖 —— 在 preview 上生成的批次即为次日生产所用的批次。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
