### PR TITLE
feat: auto-dismiss oddeNova import notice after 4s

### DIFF
--- a/src/hooks/useOddeNovaImport.ts
+++ b/src/hooks/useOddeNovaImport.ts
@@ -53,5 +53,11 @@ export function useOddeNovaImport(
       .catch(() => setResult({ status: 'error', reason: 'invalid' }));
   }, [importer, isPersistent, isReady, request]);
 
+  useEffect(() => {
+    if (result.status !== 'success' && result.status !== 'error') return;
+    const timer = window.setTimeout(() => setResult({ status: 'idle' }), 4000);
+    return () => window.clearTimeout(timer);
+  }, [result]);
+
   return result;
 }


### PR DESCRIPTION
## Summary
- The import success/error banner (`OddeNovaImportNotice`) stayed on screen indefinitely with no way to dismiss it
- `useOddeNovaImport` now resets its result to `idle` 4s after a success/error, so the notice clears itself automatically

## Test plan
- [x] `npx vitest run src/hooks/__tests__/useOddeNovaImport.test.tsx src/components/__tests__/OddeNovaImportNotice.test.tsx` — 13 passed
- [x] Full `npm test` (via pre-commit hook) — 325 passed
- [x] Verified in browser: triggered an "unsupported version" import notice, confirmed it's visible at 300ms and gone by 4.5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)