### PR TITLE
feat: compress oddeNova import URLs and keep them out of the terminal

### DIFF
--- a/skills/oddenova-strudel/SKILL.md
+++ b/skills/oddenova-strudel/SKILL.md
@@ -14,10 +14,10 @@ Create the complete composition in Codex, then send it to oddeNova with the bund
 3. Generate a complete program containing a `// STYLE | BPM: N` comment, `setcps`, one `stack`, and semantic `/* @layer NAME */` markers with a one-line intent comment after each marker.
 4. Self-review the music, API names, and samples. State only that the code was reviewed; never claim Strudel browser or runtime validation.
 5. Build the protocol payload below. Keep `messages` to music requests and compact assistant change summaries; omit reasoning, tool traces, and unrelated conversation. Match `locale`, summaries, and code comments to the user's language.
-6. Resolve `scripts/open-in-oddenova.mjs` relative to this file and send the JSON over stdin. Invoke it without flags for production. Add `--base-url` only when the user names a non-production target. The helper prints the URL before attempting to open it.
-7. Return the printed URL when automatic browser opening is unavailable. Tell the user to press oddeNova's play control; never autoplay.
+6. Resolve `scripts/open-in-oddenova.mjs` relative to this file and send the JSON over stdin. Invoke it without flags for production. Add `--base-url` only when the user names a non-production target. By default the helper compresses the payload, opens the browser, and prints a short summary plus the path of a local fallback link file — it does not print the URL (only `--print-only` does).
+7. Tell the user the piece opened in their browser and to press oddeNova's play control; never autoplay. If the helper warned that the browser could not open, point the user to the fallback file path from the helper output instead.
 
-Do not create project files unless the user explicitly asks for an output file. Do not call `/api/share`. Do not copy or run oddeNova's internal agent loop.
+Never paste the full import URL — or any long base64/encoded blob — into the conversation; refer to the fallback file path instead. Do not create project files unless the user explicitly asks for an output file. Do not call `/api/share`. Do not copy or run oddeNova's internal agent loop.
 
 ## Creation and import example
 

--- a/skills/oddenova-strudel/scripts/open-in-oddenova.mjs
+++ b/skills/oddenova-strudel/scripts/open-in-oddenova.mjs
@@ -1,18 +1,23 @@
 #!/usr/bin/env node
 
 import { spawn as spawnProcess } from 'node:child_process';
-import { realpathSync } from 'node:fs';
+import { realpathSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { deflateRawSync } from 'node:zlib';
 
 export const ODDENOVA_IMPORT_PROTOCOL_VERSION = 1;
 export const ODDENOVA_IMPORT_SOURCE = 'oddenova-strudel-skill';
 export const DEFAULT_BASE_URL = 'https://www.oddenova.com';
 export const MAX_IMPORT_URL_BYTES = 32 * 1024;
 
+// `z:` marks a deflate-raw compressed payload; the app also accepts the legacy
+// uncompressed base64url form for links minted by older helper versions.
 export function buildImportUrl(payload, baseUrl = DEFAULT_BASE_URL) {
   const root = baseUrl.replace(/[?#].*$/, '').replace(/\/+$/, '');
-  const encoded = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
-  return `${root}/#oddenova=${encoded}`;
+  const compressed = deflateRawSync(Buffer.from(JSON.stringify(payload), 'utf8'), { level: 9 });
+  return `${root}/#oddenova=z:${compressed.toString('base64url')}`;
 }
 
 export function fitPayloadToUrl(payload, baseUrl = DEFAULT_BASE_URL) {
@@ -57,6 +62,29 @@ export function launchImportUrl(
   }
 }
 
+function escapeHtml(value) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+}
+
+// The full import URL is several KiB of encoded text, so the CLI keeps it out
+// of the terminal by default and stores it in a clickable redirect file the
+// user can open when the automatic browser launch fails.
+export function writeFallbackLinkFile(url, projectId, { directory = tmpdir(), writeFile = writeFileSync } = {}) {
+  const safeId = projectId.replace(/[^A-Za-z0-9._-]/g, '-');
+  const path = join(directory, `oddenova-import-${safeId}.html`);
+  const escaped = escapeHtml(url);
+  writeFile(
+    path,
+    `<!doctype html>\n<meta charset="utf-8">\n<meta http-equiv="refresh" content="0;url=${escaped}">\n<title>oddeNova import</title>\n<p><a href="${escaped}">Open in oddeNova</a></p>\n`,
+    'utf8',
+  );
+  return path;
+}
+
 function parseArguments(argv) {
   let baseUrl = DEFAULT_BASE_URL;
   let printOnly = false;
@@ -97,16 +125,22 @@ export async function runCli(
   try {
     const { baseUrl, printOnly } = parseArguments(argv);
     const payload = JSON.parse(await readInput(stdin));
-    const { url } = fitPayloadToUrl(payload, baseUrl);
-    stdout.write(`${url}\n`);
+    const { payload: fitted, url } = fitPayloadToUrl(payload, baseUrl);
 
-    if (!printOnly) {
-      launchImportUrl(url, {
-        platform,
-        spawn,
-        warn: (message) => stderr.write(`${message}\n`),
-      });
+    if (printOnly) {
+      stdout.write(`${url}\n`);
+      return 0;
     }
+
+    const fallbackPath = writeFallbackLinkFile(url, fitted.projectId);
+    const sizeKiB = (Buffer.byteLength(url, 'utf8') / 1024).toFixed(1);
+    stdout.write(`Opening oddeNova import in the browser (project ${fitted.projectId}, URL ${sizeKiB} KiB).\n`);
+    stdout.write(`If the browser did not open, open this file: ${fallbackPath}\n`);
+    launchImportUrl(url, {
+      platform,
+      spawn,
+      warn: (message) => stderr.write(`${message}\n`),
+    });
     return 0;
   } catch (error) {
     stderr.write(`${error.message}\n`);

--- a/skills/oddenova-strudel/scripts/open-in-oddenova.test.mjs
+++ b/skills/oddenova-strudel/scripts/open-in-oddenova.test.mjs
@@ -1,11 +1,13 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
 import { mkdtempSync, readFileSync, rmSync, symlinkSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { Readable } from 'node:stream';
 import { fileURLToPath } from 'node:url';
 import test from 'node:test';
+import { inflateRawSync } from 'node:zlib';
 
 import {
   buildImportUrl,
@@ -13,6 +15,7 @@ import {
   isMainModule,
   launchImportUrl,
   runCli,
+  writeFallbackLinkFile,
 } from './open-in-oddenova.mjs';
 
 const scriptPath = fileURLToPath(new URL('./open-in-oddenova.mjs', import.meta.url));
@@ -32,13 +35,14 @@ const payload = {
 
 function decodeImportUrl(url) {
   const encoded = new URL(url).hash.slice('#oddenova='.length);
-  return JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8'));
+  assert.equal(encoded.startsWith('z:'), true, 'expected a compressed z: fragment');
+  return JSON.parse(inflateRawSync(Buffer.from(encoded.slice(2), 'base64url')).toString('utf8'));
 }
 
-test('buildImportUrl preserves Unicode protocol payloads with Base64URL', () => {
+test('buildImportUrl compresses Unicode protocol payloads behind the z: marker', () => {
   const url = buildImportUrl(payload);
 
-  assert.match(url, /^https:\/\/www\.oddenova\.com\/#oddenova=[A-Za-z0-9_-]+$/);
+  assert.match(url, /^https:\/\/www\.oddenova\.com\/#oddenova=z:[A-Za-z0-9_-]+$/);
   assert.deepEqual(decodeImportUrl(url), payload);
 });
 
@@ -49,10 +53,12 @@ test('buildImportUrl normalizes an overridden base URL', () => {
   assert.deepEqual(decodeImportUrl(url), payload);
 });
 
+// Random base64 keeps the fixtures incompressible so they still overflow the
+// URL budget now that buildImportUrl deflates the payload.
 test('fitPayloadToUrl trims oldest messages but retains the latest two', () => {
   const messages = Array.from({ length: 4 }, (_, index) => ({
     role: index % 2 === 0 ? 'user' : 'assistant',
-    content: `${index}:${'x'.repeat(9_000)}`,
+    content: `${index}:${randomBytes(12_000).toString('base64')}`,
   }));
   const original = { ...payload, messages };
 
@@ -65,13 +71,14 @@ test('fitPayloadToUrl trims oldest messages but retains the latest two', () => {
 });
 
 test('fitPayloadToUrl refuses to truncate oversized Strudel code', () => {
-  const oversized = { ...payload, code: 'x'.repeat(25_000), messages: [] };
+  const code = randomBytes(30_000).toString('base64');
+  const oversized = { ...payload, code, messages: [] };
 
   assert.throws(
     () => fitPayloadToUrl(oversized),
     new Error('Import URL exceeds 32 KiB without truncating Strudel code'),
   );
-  assert.equal(oversized.code.length, 25_000);
+  assert.equal(oversized.code, code);
 });
 
 test('launchImportUrl selects the platform browser command and detaches it', () => {
@@ -126,7 +133,7 @@ test('runCli prints the overridden URL and print-only skips browser launch', asy
   assert.equal(spawnCalled, false);
 });
 
-test('runCli warns on launch failure after printing the URL and still succeeds', async () => {
+test('runCli default output is a summary with a fallback file, never the full URL', async () => {
   let stdout = '';
   let stderr = '';
 
@@ -139,8 +146,30 @@ test('runCli warns on launch failure after printing the URL and still succeeds',
   });
 
   assert.equal(exitCode, 0);
-  assert.equal(stdout.startsWith('https://www.oddenova.com/#oddenova='), true);
+  assert.equal(stdout.includes('#oddenova='), false);
+  assert.match(stdout, /Opening oddeNova import in the browser \(project project-1, URL [\d.]+ KiB\)\./);
+  assert.match(stdout, /If the browser did not open, open this file: .*oddenova-import-project-1\.html/);
   assert.match(stderr, /Warning: Could not open browser: launcher unavailable/);
+
+  const fallbackPath = stdout.match(/open this file: (.*)\n/)[1];
+  const html = readFileSync(fallbackPath, 'utf8');
+  const href = html.match(/<a href="([^"]+)">/)[1];
+  assert.deepEqual(decodeImportUrl(href), payload);
+  rmSync(fallbackPath, { force: true });
+});
+
+test('writeFallbackLinkFile sanitizes the project id and escapes the URL', () => {
+  const writes = [];
+  const path = writeFallbackLinkFile('https://example.com/#oddenova=z:abc"<>&', 'a/b:c', {
+    directory: '/fake',
+    writeFile: (...args) => writes.push(args),
+  });
+
+  assert.equal(path, join('/fake', 'oddenova-import-a-b-c.html'));
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0][0], path);
+  assert.equal(writes[0][1].includes('z:abc&quot;&lt;&gt;&amp;'), true);
+  assert.equal(writes[0][1].includes('z:abc"'), false);
 });
 
 test('isMainModule matches through a symlinked entry path', () => {

--- a/src/hooks/__tests__/useOddeNovaImport.test.tsx
+++ b/src/hooks/__tests__/useOddeNovaImport.test.tsx
@@ -134,22 +134,30 @@ describe('useOddeNovaImport', () => {
     expect(hook.getResult()).toEqual({ status: 'success', outcome: 'created', persistent: true });
   });
 
-  it('maps unsupported protocol versions separately without invoking the importer', () => {
+  it('maps unsupported protocol versions separately without invoking the importer', async () => {
     window.history.pushState(null, '', `/compose${fragment({ ...payload, protocolVersion: 2 })}`);
     const importer = vi.fn(async () => 'created' as const);
     const hook = renderImportHook(importer, true, true);
     roots.push(hook.root);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
 
     expect(hook.getResult()).toEqual({ status: 'error', reason: 'unsupported-version' });
     expect(importer).not.toHaveBeenCalled();
     expect(window.location.hash).toBe('');
   });
 
-  it('maps malformed payloads to invalid without invoking the importer', () => {
+  it('maps malformed payloads to invalid without invoking the importer', async () => {
     window.history.pushState(null, '', '/compose#oddenova=%%%');
     const importer = vi.fn(async () => 'created' as const);
     const hook = renderImportHook(importer, true, true);
     roots.push(hook.root);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
 
     expect(hook.getResult()).toEqual({ status: 'error', reason: 'invalid' });
     expect(importer).not.toHaveBeenCalled();

--- a/src/hooks/useOddeNovaImport.ts
+++ b/src/hooks/useOddeNovaImport.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 
 import {
+  ODDENOVA_IMPORT_HASH_PREFIX,
   parseOddeNovaImportHash,
   type OddeNovaImportParseResult,
   type OddeNovaImportPayload,
@@ -26,18 +27,22 @@ export function useOddeNovaImport(
     // Opening an import link while this origin is already open is a same-document
     // navigation: only the fragment changes, so consume it on hashchange too.
     const consume = () => {
-      const parsed = parseOddeNovaImportHash(window.location.hash);
-      if (parsed.kind === 'none') return;
-      pending.current = parsed;
-      imported.current = false;
-      setRequest((previous) => previous + 1);
+      const hash = window.location.hash;
+      if (!hash.startsWith(ODDENOVA_IMPORT_HASH_PREFIX)) return;
 
+      // Strip the fragment synchronously so a reload never re-imports, then
+      // decode asynchronously (decompression is a streaming API).
       history.replaceState(null, '', window.location.pathname + window.location.search);
-      if (parsed.kind === 'error') {
-        setResult({ status: 'error', reason: parsed.reason });
-      } else {
-        setResult({ status: 'loading' });
-      }
+      setResult({ status: 'loading' });
+      void parseOddeNovaImportHash(hash).then((parsed) => {
+        if (parsed.kind === 'none') return;
+        pending.current = parsed;
+        imported.current = false;
+        setRequest((previous) => previous + 1);
+        if (parsed.kind === 'error') {
+          setResult({ status: 'error', reason: parsed.reason });
+        }
+      });
     };
 
     consume();

--- a/src/lib/__tests__/oddenova-import.test.ts
+++ b/src/lib/__tests__/oddenova-import.test.ts
@@ -1,4 +1,5 @@
 // @vitest-environment happy-dom
+import { deflateRawSync } from 'node:zlib';
 import { describe, expect, it } from 'vitest';
 import {
   hashImportedContent,
@@ -22,20 +23,31 @@ function fragment(value: unknown): string {
   return `#oddenova=${btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replace(/=+$/, '')}`;
 }
 
+function compressedFragment(value: unknown): string {
+  const compressed = deflateRawSync(Buffer.from(JSON.stringify(value), 'utf8'));
+  return `#oddenova=z:${compressed.toString('base64url')}`;
+}
+
 describe('parseOddeNovaImportHash', () => {
-  it('decodes Unicode protocol version 1 payloads', () => {
-    expect(parseOddeNovaImportHash(fragment(payload))).toEqual({ kind: 'payload', payload });
+  it('decodes legacy uncompressed Unicode payloads', async () => {
+    await expect(parseOddeNovaImportHash(fragment(payload))).resolves.toEqual({ kind: 'payload', payload });
   });
 
-  it('distinguishes absent, invalid, and unsupported imports', () => {
-    expect(parseOddeNovaImportHash('')).toEqual({ kind: 'none' });
-    expect(parseOddeNovaImportHash('#oddenova=%%%')).toEqual({ kind: 'error', reason: 'invalid' });
-    expect(parseOddeNovaImportHash(fragment({ ...payload, protocolVersion: undefined })))
-      .toEqual({ kind: 'error', reason: 'invalid' });
-    expect(parseOddeNovaImportHash(fragment({ ...payload, protocolVersion: 2 })))
-      .toEqual({ kind: 'error', reason: 'unsupported-version' });
-    expect(parseOddeNovaImportHash(fragment({ ...payload, source: 'other' })))
-      .toEqual({ kind: 'error', reason: 'invalid' });
+  it('decodes deflate-raw compressed payloads behind the z: marker', async () => {
+    await expect(parseOddeNovaImportHash(compressedFragment(payload)))
+      .resolves.toEqual({ kind: 'payload', payload });
+  });
+
+  it('distinguishes absent, invalid, and unsupported imports', async () => {
+    await expect(parseOddeNovaImportHash('')).resolves.toEqual({ kind: 'none' });
+    await expect(parseOddeNovaImportHash('#oddenova=%%%')).resolves.toEqual({ kind: 'error', reason: 'invalid' });
+    await expect(parseOddeNovaImportHash('#oddenova=z:%%%')).resolves.toEqual({ kind: 'error', reason: 'invalid' });
+    await expect(parseOddeNovaImportHash(fragment({ ...payload, protocolVersion: undefined })))
+      .resolves.toEqual({ kind: 'error', reason: 'invalid' });
+    await expect(parseOddeNovaImportHash(fragment({ ...payload, protocolVersion: 2 })))
+      .resolves.toEqual({ kind: 'error', reason: 'unsupported-version' });
+    await expect(parseOddeNovaImportHash(fragment({ ...payload, source: 'other' })))
+      .resolves.toEqual({ kind: 'error', reason: 'invalid' });
   });
 });
 

--- a/src/lib/oddenova-import.ts
+++ b/src/lib/oddenova-import.ts
@@ -27,12 +27,28 @@ function isMessage(value: unknown): value is OddeNovaImportMessage {
   return (message.role === 'user' || message.role === 'assistant') && typeof message.content === 'string';
 }
 
-export function parseOddeNovaImportHash(hash: string): OddeNovaImportParseResult {
-  if (!hash.startsWith('#oddenova=')) return { kind: 'none' };
+export const ODDENOVA_IMPORT_HASH_PREFIX = '#oddenova=';
+
+function decodeBase64Url(encoded: string): Uint8Array {
+  const normalized = encoded.replaceAll('-', '+').replaceAll('_', '/');
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+  return Uint8Array.from(atob(padded), (char) => char.charCodeAt(0));
+}
+
+async function inflateRaw(bytes: Uint8Array): Promise<Uint8Array> {
+  const stream = new Blob([bytes as BlobPart]).stream().pipeThrough(new DecompressionStream('deflate-raw'));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+export async function parseOddeNovaImportHash(hash: string): Promise<OddeNovaImportParseResult> {
+  if (!hash.startsWith(ODDENOVA_IMPORT_HASH_PREFIX)) return { kind: 'none' };
   try {
-    const encoded = hash.slice('#oddenova='.length).replaceAll('-', '+').replaceAll('_', '/');
-    const padded = encoded.padEnd(Math.ceil(encoded.length / 4) * 4, '=');
-    const bytes = Uint8Array.from(atob(padded), (char) => char.charCodeAt(0));
+    const encoded = hash.slice(ODDENOVA_IMPORT_HASH_PREFIX.length);
+    // `z:` marks a deflate-raw compressed payload; the bare base64url form is
+    // the legacy uncompressed encoding from older helper versions.
+    const bytes = encoded.startsWith('z:')
+      ? await inflateRaw(decodeBase64Url(encoded.slice(2)))
+      : decodeBase64Url(encoded);
     const value = JSON.parse(new TextDecoder().decode(bytes)) as Record<string, unknown>;
     if (typeof value.protocolVersion !== 'number') {
       return { kind: 'error', reason: 'invalid' };


### PR DESCRIPTION
## Why

The skill helper printed a multi-KiB base64 import URL to stdout, and SKILL.md told the agent to return it — so every session pasted a huge encoded blob into chat, which safety filters can flag (this actually blocked a session).

## What

- **`open-in-oddenova.mjs`**: deflate-compresses the payload before base64url encoding (`#oddenova=z:...`, ~58% shorter URLs, sub-ms cost). By default it now prints only a one-line summary plus the path of a local fallback HTML link file instead of the full URL; `--print-only` keeps the raw-URL output for debugging.
- **`src/lib/oddenova-import.ts`**: `parseOddeNovaImportHash` becomes async and inflates `z:` fragments via `DecompressionStream('deflate-raw')`, while still accepting legacy uncompressed links minted by older helper versions.
- **`useOddeNovaImport`**: strips the fragment synchronously (so a reload never re-imports), then decodes asynchronously.
- **SKILL.md**: documents the new helper output and adds a hard guardrail — never paste the full import URL or any long encoded blob into the conversation.

## Verification

- `tsc --noEmit` clean; all 326 vitest tests and 11 helper `node:test` tests pass (new coverage: compressed fragment parsing, fallback file round-trip, HTML escaping, incompressible-fixture size limits).
- End-to-end: generated a compressed URL with the new helper against the Vite dev server; the app showed 导入成功, created the session with full code and history, hash consumed, no console errors. Legacy-format links verified by unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)