### PR TITLE
fix: make validate's runtime error messages accurate and locate the f…

### DIFF
--- a/src/agent/__tests__/tools.test.ts
+++ b/src/agent/__tests__/tools.test.ts
@@ -64,12 +64,56 @@ describe('validate', () => {
     expect(result.error).toMatch(/语法错误/);
   });
 
-  it('运行时错误（幻觉 API）— 返回 ok: false，error 含"运行时错误"', async () => {
+  it('运行时错误（幻觉 API）— 返回 ok: false，error 含"运行时错误"和 TidalCycles 提示', async () => {
     vi.mocked(validateCodeRuntime).mockReturnValueOnce({ ok: false, error: 'sometimesBy is not defined', kind: 'runtime' });
     const ctx = makeCtx('s("bd").sometimesBy(0.5, fast(2))');
     const result = await validate({}, ctx);
     expect(result.ok).toBe(false);
     expect(result.error).toMatch(/运行时错误/);
+    expect(result.error).toMatch(/TidalCycles/);
+  });
+
+  it('运行时错误（与 TidalCycles 专有 API 无关）— 不附加误导性的 TidalCycles 提示', async () => {
+    vi.mocked(validateCodeRuntime).mockReturnValueOnce({ ok: false, error: 'Invalid argument', kind: 'runtime' });
+    const ctx = makeCtx('s("bd").late("[0 .04]*4")');
+    const result = await validate({}, ctx);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/运行时错误/);
+    expect(result.error).not.toMatch(/TidalCycles/);
+  });
+
+  it('运行时错误（多音层）— 隔离复现出同一错误的音层，在 error 中标出 @layer 名称', async () => {
+    vi.mocked(validateCodeRuntime)
+      .mockReturnValueOnce({ ok: false, error: 'Invalid argument', kind: 'runtime' }) // full code
+      .mockReturnValueOnce({ ok: true }) // drums layer in isolation: passes
+      .mockReturnValueOnce({ ok: false, error: 'Invalid argument', kind: 'runtime' }); // bass layer in isolation: reproduces
+    const ctx = makeCtx(`setcps(0.5)
+stack(
+  /* @layer drums */
+  s("bd ~ sd ~"),
+  /* @layer bass */
+  s("bd sd").late("[0 .04]*4")
+)`);
+    const result = await validate({}, ctx);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/@layer bass/);
+  });
+
+  it('运行时错误（多音层，隔离后无法复现）— 不猜测位置', async () => {
+    vi.mocked(validateCodeRuntime)
+      .mockReturnValueOnce({ ok: false, error: 'Invalid argument', kind: 'runtime' }) // full code
+      .mockReturnValueOnce({ ok: true }) // drums layer in isolation: passes
+      .mockReturnValueOnce({ ok: true }); // bass layer in isolation: also passes (error only appears in combination)
+    const ctx = makeCtx(`setcps(0.5)
+stack(
+  /* @layer drums */
+  s("bd ~ sd ~"),
+  /* @layer bass */
+  s("bd sd").late("[0 .04]*4")
+)`);
+    const result = await validate({}, ctx);
+    expect(result.ok).toBe(false);
+    expect(result.error).not.toMatch(/@layer/);
   });
 });
 

--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -46,6 +46,32 @@ export class CommitSignal extends Error {
   }
 }
 
+// The Proxy dry-run in validateCodeRuntime throws `${name} is not defined` for
+// any undefined global. Only attach the TidalCycles-substitute hint when the
+// undefined name is actually one of these — otherwise the hint is a red
+// herring that misdirects fixes toward unrelated code (e.g. `.late()`, which
+// is a real, patternified Strudel API).
+const TIDAL_ONLY_API_ERROR = /^(by|sometimesBy|someCyclesBy|within) is not defined$/;
+
+// A runtime error message alone doesn't say which stack layer threw it. Re-run
+// the dry-run against each named layer standalone; a layer only counts as a
+// match if the *exact same* error reproduces in isolation — a different error
+// usually just means that layer depends on something defined outside it (e.g.
+// a shared variable), not that it's the culprit. This keeps false positives
+// out: we'd rather report no location than a confidently wrong one.
+function findFailingLayers(code: string, errorMessage: string): string[] {
+  const score = parseScore(code);
+  if (!score.hasStack || score.layers.length < 2) return [];
+  const matches: string[] = [];
+  for (const layer of score.layers) {
+    const result = validateCodeRuntime(layer.source);
+    if (!result.ok && result.kind === 'runtime' && result.error === errorMessage) {
+      matches.push(layer.name);
+    }
+  }
+  return matches;
+}
+
 // ----- tool definitions ------------------------------------------------------
 
 export const TOOLS: ToolDef[] = [
@@ -75,9 +101,15 @@ export const TOOLS: ToolDef[] = [
             ? `语法错误: ${runtime.error}`
             : `Syntax error: ${runtime.error}` };
         }
+        const isTidalOnlyApi = TIDAL_ONLY_API_ERROR.test(runtime.error ?? '');
+        const hintZh = isTidalOnlyApi ? '（请勿使用 TidalCycles 专有 API，如 by/sometimesBy/someCyclesBy/within；改用 .sometimes(fast(2)) 或 .every(N, fast(2)) 形式）' : '';
+        const hintEn = isTidalOnlyApi ? ' (do not use TidalCycles-specific APIs such as by/sometimesBy/someCyclesBy/within; use .sometimes(fast(2)) or .every(N, fast(2)) instead)' : '';
+        const failingLayers = findFailingLayers(code, runtime.error ?? '');
+        const locationZh = failingLayers.length > 0 ? `（错误位于 @layer ${failingLayers.join(', ')}）` : '';
+        const locationEn = failingLayers.length > 0 ? ` (error originates in @layer ${failingLayers.join(', ')})` : '';
         return { ok: false, error: zh
-          ? `运行时错误: ${runtime.error}（请勿使用 TidalCycles 专有 API，如 by/sometimesBy/someCyclesBy/within；改用 .sometimes(fast(2)) 或 .every(N, fast(2)) 形式）`
-          : `Runtime error: ${runtime.error} (do not use TidalCycles-specific APIs such as by/sometimesBy/someCyclesBy/within; use .sometimes(fast(2)) or .every(N, fast(2)) instead)` };
+          ? `运行时错误: ${runtime.error}${locationZh}${hintZh}`
+          : `Runtime error: ${runtime.error}${locationEn}${hintEn}` };
       }
       const transpilerCheck = validateCodeTranspiler(code);
       return transpilerCheck.ok


### PR DESCRIPTION
…ailing layer

The TidalCycles-substitute hint (by/sometimesBy/someCyclesBy/within) was appended to every runtime error unconditionally, misdirecting fixes toward unrelated code (e.g. .late(), which is a valid patternified API) when the real error had nothing to do with those APIs. Now it only appears when the error is actually one of those undefined-API references.

Also add layer localization: on a runtime error in a multi-layer stack(), re-run the dry-run against each named layer in isolation and report the @layer name only when the exact same error reproduces standalone, so the agent gets a real location instead of guessing.