### PR TITLE
Centralize code-diff widget colors into theme tokens

### DIFF
--- a/src/components/CodeDiffView.tsx
+++ b/src/components/CodeDiffView.tsx
@@ -43,7 +43,7 @@ function highlightedText(text: string, counterpart: string | undefined, kind: 'a
   return (
     <>
       {text.slice(0, prefix)}
-      <span className={kind === 'add' ? 'bg-emerald-300/20' : 'bg-rose-300/20'}>{changed}</span>
+      <span className={kind === 'add' ? 'bg-diff-add/20' : 'bg-diff-remove/20'}>{changed}</span>
       {text.slice(changedEnd)}
     </>
   );
@@ -57,22 +57,22 @@ export function CodeDiffView({ messageId, revision, expanded, onToggle }: CodeDi
   );
 
   return (
-    <div className="mt-4 -ml-1 overflow-hidden rounded-md border border-[#93C2FF]/30 bg-bg-primary/35 animate-fade-in">
-      <div className="flex w-full items-stretch bg-bg-primary/60 text-[11px] text-[#93C2FF]/70">
+    <div className="mt-4 -ml-1 overflow-hidden rounded-md border-1 border-diff-accent/50 bg-bg-primary/35 animate-fade-in">
+      <div className="flex w-full items-stretch bg-bg-primary/60 text-[11px] text-diff-accent/70">
         <button
           type="button"
           data-code-diff-toggle={messageId}
           aria-expanded={expanded}
           onClick={onToggle}
-          className="flex min-w-0 flex-1 items-center gap-1.5 px-2 py-1.5 text-left transition-colors hover:bg-bg-primary/80 hover:text-[#93C2FF]/90"
+          className="flex min-w-0 flex-1 items-center gap-1.5 px-2 py-1.5 text-left transition-colors hover:bg-bg-primary/80 hover:text-diff-accent/90"
         >
           <ChevronRightIcon
             size={12}
             className={`shrink-0 transition-transform ${expanded ? 'rotate-90' : ''}`}
           />
           <span>{t('viewChanges')}</span>
-          <span className="text-emerald-300/75">+{diff.additions}</span>
-          <span className="text-rose-300/75">−{diff.deletions}</span>
+          <span className="text-diff-add/75">+{diff.additions}</span>
+          <span className="text-diff-remove/75">−{diff.deletions}</span>
           {revision.playbackStatus === 'failed' && (
             <span className="ml-1 truncate text-amber-300/70">{t('revisionPlaybackFailed')}</span>
           )}
@@ -85,7 +85,7 @@ export function CodeDiffView({ messageId, revision, expanded, onToggle }: CodeDi
               setTimeout(() => setCopied(false), 2000);
             });
           }}
-          className="px-2 py-1.5 transition-colors hover:bg-bg-primary/80 hover:text-[#93C2FF]/90"
+          className="px-2 py-1.5 transition-colors hover:bg-bg-primary/80 hover:text-diff-accent/90"
           title={t('copyCode')}
         >
           {copied ? <CheckIcon size={13} /> : <CopyIcon size={13} />}
@@ -93,7 +93,7 @@ export function CodeDiffView({ messageId, revision, expanded, onToggle }: CodeDi
       </div>
 
       {expanded && (
-        <div className="border-t border-[#93C2FF]/15 bg-[#080a0d] py-1 animate-fade-in">
+        <div className="border-t border-diff-accent/15 bg-[#080a0d] py-1 animate-fade-in">
           {diff.groups.length === 0 && (
             <div className="px-3 py-3 text-[11px] text-text-muted">{t('noCodeChanges')}</div>
           )}
@@ -101,8 +101,8 @@ export function CodeDiffView({ messageId, revision, expanded, onToggle }: CodeDi
             <section key={group.key} data-diff-group={group.name} className="py-1.5 first:pt-0 last:pb-0">
               <div className="sticky top-0 z-[1] flex items-center gap-2 border-y border-white/[0.055] bg-[#101319] px-2.5 py-1 font-mono text-[10px] tracking-[0.16em] text-white/55">
                 <span>{group.name.toUpperCase()}</span>
-                <span className="tracking-normal text-emerald-300/60">+{group.additions}</span>
-                <span className="tracking-normal text-rose-300/60">−{group.deletions}</span>
+                <span className="tracking-normal text-diff-add/60">+{group.additions}</span>
+                <span className="tracking-normal text-diff-remove/60">−{group.deletions}</span>
               </div>
               <div className="overflow-x-auto py-1 font-mono text-[11px] leading-[1.65]">
                 {/* w-max makes every row span the widest line, so row tints
@@ -118,9 +118,9 @@ export function CodeDiffView({ messageId, revision, expanded, onToggle }: CodeDi
                     );
                   }
                   const tone = row.kind === 'add'
-                    ? 'bg-emerald-400/[0.075] text-emerald-50/80'
+                    ? 'bg-diff-add/[0.075] text-white/60'
                     : row.kind === 'remove'
-                      ? 'bg-rose-400/[0.075] text-rose-50/75'
+                      ? 'bg-diff-remove/[0.075] text-white/60'
                       : 'text-white/42';
                   const sign = row.kind === 'add' ? '+' : row.kind === 'remove' ? '−' : ' ';
                   const counterpart = counterpartFor(group.rows, index);

--- a/src/components/ConversationView.tsx
+++ b/src/components/ConversationView.tsx
@@ -152,7 +152,7 @@ function parseInlineMarkdown(text: string, keyPrefix: string, tone: MarkdownTone
             href={href}
             target="_blank"
             rel="noreferrer"
-            className="text-[#93C2FF] underline decoration-[#93C2FF]/40 underline-offset-2 hover:decoration-[#93C2FF]"
+            className="text-diff-accent underline decoration-diff-accent/40 underline-offset-2 hover:decoration-diff-accent"
           >
             {parseInlineMarkdown(label, `${keyPrefix}-link-${key}`, tone)}
           </a>,
@@ -348,7 +348,7 @@ function MarkdownText({ content, tone = 'default' }: { content: string; tone?: M
         i += 1;
       }
       blocks.push(
-        <blockquote key={`md-quote-${key++}`} className="my-1 border-l border-[#93C2FF]/30 pl-3 text-text-secondary">
+        <blockquote key={`md-quote-${key++}`} className="my-1 border-l border-diff-accent/30 pl-3 text-text-secondary">
           {parseInlineMarkdown(quoted.join('\n'), `md-quote-${key}`, tone)}
         </blockquote>,
       );
@@ -1235,11 +1235,11 @@ export default function ConversationView({
                 const code = msg.code;
                 const lineCount = code.split('\n').length;
                 return (
-                  <div className="mt-4 -ml-1 rounded-md border border-[#93C2FF]/30 overflow-hidden animate-fade-in">
-                    <div className="w-full flex items-center bg-bg-primary/60 text-[11px] text-[#93C2FF]/70">
+                  <div className="mt-4 -ml-1 rounded-md border border-diff-accent/70 overflow-hidden animate-fade-in">
+                    <div className="w-full flex items-center bg-bg-primary/60 text-[11px] text-diff-accent/70">
                       <button
                         onClick={() => toggleCode(msg.id)}
-                        className="flex-1 flex items-center gap-1.5 px-2 py-1.5 hover:text-[#93C2FF]/90 hover:bg-bg-primary/80 transition-colors text-left"
+                        className="flex-1 flex items-center gap-1.5 px-2 py-1.5 hover:text-diff-accent/90 hover:bg-bg-primary/80 transition-colors text-left"
                       >
                         <span>{t('strudelCode')}</span>
                         <span>· {lineCount} {t('lines')}</span>
@@ -1251,7 +1251,7 @@ export default function ConversationView({
                             setTimeout(() => setCopiedId(null), 2000);
                           });
                         }}
-                        className="px-2 py-1.5 text-[#93C2FF]/70 hover:text-[#93C2FF]/90 hover:bg-bg-primary/80 transition-colors"
+                        className="px-2 py-1.5 text-diff-accent/70 hover:text-diff-accent/90 hover:bg-bg-primary/80 transition-colors"
                         title={t('copyCode')}
                       >
                         {copiedId === msg.id ? <CheckIcon size={13} /> : <CopyIcon size={13} />}

--- a/src/index.css
+++ b/src/index.css
@@ -47,13 +47,16 @@
   --color-accent: #434343;
   --color-accent-light: #434343;
   --color-accent-glow: rgba(108, 92, 231, 0.4);
-  --color-text-primary: #D4D4D4;
+  --color-text-primary: #C0C0C0;
   --color-text-secondary: #B8B8B8;
   --color-text-muted: #747474;
   --color-border: #323232;
   --color-success: #00b894;
   --color-error: #CC3803;
   --color-warning: #7E936F;
+  --color-diff-accent: #5295EB;
+  --color-diff-add: #28AB42;
+  --color-diff-remove: #DE573F;
 
   --font-jinghua-laosongti: '京華老宋体', serif;
   --font-eb-garamond: 'EB Garamond', serif;


### PR DESCRIPTION
Introduce --color-diff-accent/-add/-remove theme tokens and replace the hard-coded hex and emerald/rose palette values across CodeDiffView and the ConversationView code widgets. Diff row text is now neutral gray with the red/green carried by the row background tint instead of the text color.