### PR TITLE
Retry transient agent requests safely

### DIFF
--- a/src/agent/__tests__/loop.test.ts
+++ b/src/agent/__tests__/loop.test.ts
@@ -37,6 +37,22 @@ function makeCapturingLLM(commitCode = 's("bd")') {
   return { llm, calls };
 }
 
+async function runWithTimers<T>(operation: () => Promise<T>): Promise<T> {
+  vi.useFakeTimers();
+  try {
+    const settled = operation().then(
+      (value) => ({ ok: true as const, value }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
+    await vi.runAllTimersAsync();
+    const outcome = await settled;
+    if (!outcome.ok) throw outcome.error;
+    return outcome.value;
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
 describe('runAgentLoop — conversationHistory message ordering', () => {
   it('inserts history between system prompt and user turn', async () => {
     const history: ConversationTurn[] = [
@@ -143,16 +159,30 @@ describe('runAgentLoop — pure chat replies', () => {
     });
     expect(events).toEqual([
       { kind: 'iteration', index: 1 },
-      { kind: 'assistant_reply_delta', delta: '当然可以，' },
-      { kind: 'assistant_reply_delta', delta: '我们先聊聊。' },
+      {
+        kind: 'assistant_reply_delta',
+        delta: '当然可以，',
+        attemptId: expect.any(String),
+      },
+      {
+        kind: 'assistant_reply_delta',
+        delta: '我们先聊聊。',
+        attemptId: expect.any(String),
+      },
+      {
+        kind: 'request_attempt_succeeded',
+        attemptId: expect.any(String),
+      },
     ]);
     expect(events.some((event) => event.kind === 'warn')).toBe(false);
   });
 
   it('throws a diagnosable error when the model returns no tools and no useful text', async () => {
     const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    let calls = 0;
     const llm: LLMCaller = {
       async chatWithTools() {
+        calls += 1;
         return {
           content: '',
           reasoning_content: 'unfinished reasoning',
@@ -162,20 +192,189 @@ describe('runAgentLoop — pure chat replies', () => {
       },
     };
 
-    await expect(runAgentLoop({
+    await expect(runWithTimers(() => runAgentLoop({
       initialCode: 'setcps(0.5)\nstack(s("bd"))',
       instruction: '更新一下',
       systemPrompt: 'You are a music assistant.',
       llm,
-    })).rejects.toBeInstanceOf(EmptyAgentResponseError);
+    }))).rejects.toBeInstanceOf(EmptyAgentResponseError);
 
-    expect(consoleWarn).toHaveBeenCalledWith('[agent] Empty model response', {
+    expect(calls).toBe(3);
+    expect(consoleWarn).toHaveBeenCalledTimes(2);
+    consoleWarn.mockRestore();
+  });
+});
+
+describe('runAgentLoop — request retries', () => {
+  it('retries a partial network stream and executes the successful tool once', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    let calls = 0;
+    const events: ProgressEvent[] = [];
+    const llm: LLMCaller = {
+      async chatWithTools(_messages, _tools, onTextDelta, onReasoningDelta) {
+        calls += 1;
+        if (calls === 1) {
+          onReasoningDelta?.('discarded reasoning');
+          onTextDelta?.('discarded text');
+          throw new TypeError('network error');
+        }
+        return {
+          content: null,
+          toolCalls: [
+            {
+              id: 'set-code-1',
+              name: 'setCode',
+              arguments: JSON.stringify({ code: 's("bd")' }),
+            },
+            {
+              id: 'commit-1',
+              name: 'commit',
+              arguments: JSON.stringify({ explanation: 'done' }),
+            },
+          ],
+        };
+      },
+    };
+
+    const result = await runWithTimers(() => runAgentLoop({
+      initialCode: '',
+      instruction: 'add drums',
+      systemPrompt: 'system',
+      llm,
+      onProgress: (event) => events.push(event),
+    }));
+
+    expect(calls).toBe(2);
+    expect(result).toMatchObject({ code: 's("bd")', committed: true });
+    expect(events.filter((event) => event.kind === 'commit')).toHaveLength(1);
+    expect(events.filter((event) => event.kind === 'tool_call')).toHaveLength(2);
+    expect(events).toContainEqual({
+      kind: 'request_attempt_discarded',
+      attemptId: expect.any(String),
+    });
+    expect(consoleWarn).toHaveBeenCalledWith(
+      '[agent] Retrying request',
+      expect.objectContaining({
+        iteration: 1,
+        retryAttempt: 1,
+        maxRetries: 2,
+        errorName: 'TypeError',
+        errorMessage: 'network error',
+        receivedPartial: true,
+      }),
+    );
+    consoleWarn.mockRestore();
+  });
+
+  it('stops after the initial attempt and two retries', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const llm: LLMCaller = {
+      chatWithTools: vi.fn(async () => {
+        throw new TypeError('network error');
+      }),
+    };
+
+    await expect(runWithTimers(() => runAgentLoop({
+      initialCode: '',
+      instruction: 'add drums',
+      systemPrompt: 'system',
+      llm,
+    }))).rejects.toThrow('network error');
+
+    expect(llm.chatWithTools).toHaveBeenCalledTimes(3);
+    expect(consoleWarn).toHaveBeenCalledTimes(2);
+    consoleWarn.mockRestore();
+  });
+
+  it('retries empty responses and logs safe retry metadata', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    let calls = 0;
+    const llm: LLMCaller = {
+      async chatWithTools() {
+        calls += 1;
+        return calls === 1
+          ? {
+              content: '',
+              reasoning_content: 'partial',
+              toolCalls: [],
+            }
+          : {
+              content: 'recovered',
+              toolCalls: [],
+            };
+      },
+    };
+
+    const result = await runWithTimers(() => runAgentLoop({
+      initialCode: '',
+      instruction: 'hello',
+      systemPrompt: 'system',
+      llm,
+    }));
+
+    expect(result.explanation).toBe('recovered');
+    expect(consoleWarn).toHaveBeenCalledWith('[agent] Retrying request', {
       iteration: 1,
-      enableThinking: true,
-      hasReasoning: true,
-      hasUsage: true,
+      retryAttempt: 1,
+      maxRetries: 2,
+      errorName: 'EmptyAgentResponseError',
+      errorMessage: 'Model returned no text or tool calls',
+      status: undefined,
+      delayMs: expect.any(Number),
+      receivedPartial: false,
     });
     consoleWarn.mockRestore();
+  });
+
+  it('does not retry a non-transient 401', async () => {
+    const error = Object.assign(new Error('Unauthorized'), { status: 401 });
+    const llm: LLMCaller = {
+      chatWithTools: vi.fn(async () => {
+        throw error;
+      }),
+    };
+
+    await expect(runAgentLoop({
+      initialCode: '',
+      instruction: 'hello',
+      systemPrompt: 'system',
+      llm,
+    })).rejects.toBe(error);
+
+    expect(llm.chatWithTools).toHaveBeenCalledOnce();
+  });
+
+  it('aborts during backoff without starting another request', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.useFakeTimers();
+    try {
+      const controller = new AbortController();
+      const llm: LLMCaller = {
+        chatWithTools: vi.fn(async () => {
+          throw new TypeError('network error');
+        }),
+      };
+      const settled = runAgentLoop({
+        initialCode: '',
+        instruction: 'hello',
+        systemPrompt: 'system',
+        llm,
+        signal: controller.signal,
+      }).then(
+        () => ({ error: undefined }),
+        (error: unknown) => ({ error }),
+      );
+
+      await vi.advanceTimersByTimeAsync(0);
+      controller.abort();
+
+      const outcome = await settled;
+      expect(outcome.error).toMatchObject({ name: 'AbortError' });
+      expect(llm.chatWithTools).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+      consoleWarn.mockRestore();
+    }
   });
 });
 

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -68,9 +68,11 @@ export type ProgressEvent =
   | { kind: 'tool_result'; name: string; ok: boolean; error?: string }
   | { kind: 'commit'; code: string }
   | { kind: 'assistant_text'; text: string }
-  | { kind: 'assistant_text_delta'; delta: string }
-  | { kind: 'assistant_reply_delta'; delta: string }
-  | { kind: 'reasoning_delta'; delta: string }
+  | { kind: 'assistant_text_delta'; delta: string; attemptId?: string }
+  | { kind: 'assistant_reply_delta'; delta: string; attemptId?: string }
+  | { kind: 'reasoning_delta'; delta: string; attemptId?: string }
+  | { kind: 'request_attempt_discarded'; attemptId: string }
+  | { kind: 'request_attempt_succeeded'; attemptId: string }
   | { kind: 'warn'; message: string };
 
 export type ConversationTurn = { role: 'user' | 'assistant'; content: string };

--- a/src/agent/loop.ts
+++ b/src/agent/loop.ts
@@ -16,7 +16,13 @@ import {
   type ToolContext,
 } from './tools';
 import { parseScore, summariseScore } from './parser';
-import { getErrorMessage } from '../lib/errors';
+import {
+  getErrorMessage,
+  getErrorStatus,
+  getRetryDelayMs,
+  isRetryableRequestError,
+  waitForRetryDelay,
+} from '../lib/errors';
 
 /** Anthropic extended thinking block, must be echoed back verbatim in multi-turn. */
 export type ThinkingBlock = { type: 'thinking'; thinking: string; signature: string };
@@ -103,12 +109,108 @@ export class EmptyAgentResponseError extends Error {
   }
 }
 
+const MAX_REQUEST_ATTEMPTS = 3;
+let requestAttemptSequence = 0;
+
+function nextRequestAttemptId(iteration: number, attempt: number): string {
+  requestAttemptSequence += 1;
+  return `agent-${Date.now()}-${iteration}-${attempt}-${requestAttemptSequence}`;
+}
+
 // Wrap a streaming-delta progress event, or undefined when there's no listener.
 function makeProgressDelta(
   onProgress: ((e: ProgressEvent) => void) | undefined,
   kind: 'assistant_text_delta' | 'assistant_reply_delta' | 'reasoning_delta',
+  attemptId: string,
+  onDelta: () => void,
 ): ((delta: string) => void) | undefined {
-  return onProgress ? (delta: string) => onProgress({ kind, delta }) : undefined;
+  return onProgress
+    ? (delta: string) => {
+        onDelta();
+        onProgress({ kind, delta, attemptId });
+      }
+    : undefined;
+}
+
+type LLMResponse = Awaited<ReturnType<LLMCaller['chatWithTools']>>;
+
+interface ChatWithToolsRetryOptions {
+  llm: LLMCaller;
+  messages: ChatMsg[];
+  tools: ReturnType<typeof getOpenAIToolSchemas>;
+  iteration: number;
+  onProgress?: (event: ProgressEvent) => void;
+  signal?: AbortSignal;
+  enableThinking: boolean;
+}
+
+async function chatWithToolsWithRetry(
+  opts: ChatWithToolsRetryOptions,
+): Promise<LLMResponse> {
+  const {
+    llm,
+    messages,
+    tools,
+    iteration,
+    onProgress,
+    signal,
+    enableThinking,
+  } = opts;
+
+  for (let attempt = 1; attempt <= MAX_REQUEST_ATTEMPTS; attempt++) {
+    const attemptId = nextRequestAttemptId(iteration, attempt);
+    let receivedPartial = false;
+    const markPartial = () => {
+      receivedPartial = true;
+    };
+
+    try {
+      const response = await llm.chatWithTools(
+        messages,
+        tools,
+        makeProgressDelta(
+          onProgress,
+          enableThinking ? 'assistant_text_delta' : 'assistant_reply_delta',
+          attemptId,
+          markPartial,
+        ),
+        makeProgressDelta(onProgress, 'reasoning_delta', attemptId, markPartial),
+        signal,
+        enableThinking,
+      );
+
+      if (!response.content?.trim() && response.toolCalls.length === 0) {
+        throw new EmptyAgentResponseError();
+      }
+
+      onProgress?.({ kind: 'request_attempt_succeeded', attemptId });
+      return response;
+    } catch (error) {
+      onProgress?.({ kind: 'request_attempt_discarded', attemptId });
+      if (
+        attempt === MAX_REQUEST_ATTEMPTS
+        || !isRetryableRequestError(error, signal)
+      ) {
+        throw error;
+      }
+
+      const retryAttempt = attempt as 1 | 2;
+      const delayMs = getRetryDelayMs(retryAttempt);
+      console.warn('[agent] Retrying request', {
+        iteration,
+        retryAttempt,
+        maxRetries: MAX_REQUEST_ATTEMPTS - 1,
+        errorName: error instanceof Error ? error.name : typeof error,
+        errorMessage: getErrorMessage(error),
+        status: getErrorStatus(error),
+        delayMs,
+        receivedPartial,
+      });
+      await waitForRetryDelay(delayMs, signal);
+    }
+  }
+
+  throw new Error('Agent request retry loop exited unexpectedly');
 }
 
 // Count CJK code points (≈1 token/char) for the system-prompt token estimate.
@@ -206,12 +308,15 @@ export async function runAgentLoop(opts: RunAgentOptions): Promise<RunAgentResul
     iterations = i + 1;
     onProgress?.({ kind: 'iteration', index: iterations });
 
-    const onTextDelta = makeProgressDelta(
+    const resp = await chatWithToolsWithRetry({
+      llm,
+      messages,
+      tools,
+      iteration: iterations,
       onProgress,
-      enableThinking ? 'assistant_text_delta' : 'assistant_reply_delta',
-    );
-    const onReasoningDelta = makeProgressDelta(onProgress, 'reasoning_delta');
-    const resp = await llm.chatWithTools(messages, tools, onTextDelta, onReasoningDelta, signal, enableThinking);
+      signal,
+      enableThinking,
+    });
     if (resp.usage) lastUsage = resp.usage;
 
     if (resp.content && resp.content.trim()) {
@@ -238,18 +343,10 @@ export async function runAgentLoop(opts: RunAgentOptions): Promise<RunAgentResul
     });
 
     if (resp.toolCalls.length === 0) {
-      // No tools requested. If the model returned substantive text and did not
-      // mutate code, this is a legal chat turn in unified-agent mode.
+      // No tools requested. A substantive text response is a legal chat turn
+      // in unified-agent mode; empty responses were rejected by the request
+      // retry boundary before reaching this point.
       const text = resp.content?.trim() || '';
-      if (!text && state.code === initialCode) {
-        console.warn('[agent] Empty model response', {
-          iteration: iterations,
-          enableThinking,
-          hasReasoning: !!(resp.reasoning_content || resp.thinking_blocks?.length),
-          hasUsage: !!resp.usage,
-        });
-        throw new EmptyAgentResponseError();
-      }
       if (text) {
         explanation = text;
         if (state.code === initialCode) {

--- a/src/hooks/__tests__/useSessions.test.ts
+++ b/src/hooks/__tests__/useSessions.test.ts
@@ -9,7 +9,10 @@ import { t } from '../../lib/i18n';
 import type { OddeNovaImportPayload } from '../../lib/oddenova-import';
 import {
   applyAppendAssistantDelta,
+  applyAppendProgressDelta,
+  applyDiscardAgentAttempt,
   applyFinalizeLastAssistantMessage,
+  applyFinalizeAgentAttempt,
   applyRefreshEmptySessionForReuse,
   applyTruncate,
   applyTruncateAndEdit,
@@ -653,6 +656,77 @@ describe('assistant streaming helpers', () => {
     expect(result.messages[1]).toMatchObject({ content: '写好了', code: 'setcps(0.5)' });
     expect(result.messages[2]).toMatchObject({ role: 'assistant', content: '你觉得' });
     expect(result.messages[2].code).toBeUndefined();
+  });
+
+  it('isolates streamed deltas by request attempt', () => {
+    const first = applyAppendAssistantDelta(makeSession(), 'old partial', 'attempt-1');
+    const second = applyAppendAssistantDelta(first, 'new partial', 'attempt-2');
+
+    expect(second.messages).toMatchObject([
+      { content: 'old partial', agentAttemptId: 'attempt-1' },
+      { content: 'new partial', agentAttemptId: 'attempt-2' },
+    ]);
+  });
+
+  it('keeps reasoning deltas from different attempts in separate messages', () => {
+    const first = applyAppendProgressDelta(
+      makeSession(),
+      'old reasoning',
+      'reasoning',
+      'attempt-1',
+    );
+    const second = applyAppendProgressDelta(
+      first,
+      'new reasoning',
+      'reasoning',
+      'attempt-2',
+    );
+
+    expect(second.messages).toMatchObject([
+      { content: 'old reasoning', agentAttemptId: 'attempt-1' },
+      { content: 'new reasoning', agentAttemptId: 'attempt-2' },
+    ]);
+  });
+
+  it('discards only messages from the failed request attempt', () => {
+    const session = makeSession({
+      messages: [
+        { id: 'user', role: 'user', content: '写一段鼓', timestamp: 1 },
+        {
+          id: 'reasoning',
+          role: 'progress',
+          progressKind: 'reasoning',
+          content: 'partial',
+          timestamp: 2,
+          agentAttemptId: 'attempt-1',
+        },
+        {
+          id: 'reply',
+          role: 'assistant',
+          content: 'retry output',
+          timestamp: 3,
+          agentAttemptId: 'attempt-2',
+        },
+      ],
+    });
+
+    expect(applyDiscardAgentAttempt(session, 'attempt-1').messages.map((message) => message.id))
+      .toEqual(['user', 'reply']);
+  });
+
+  it('finalizes successful streamed messages by removing transient markers', () => {
+    const session = makeSession({
+      messages: [{
+        id: 'reply',
+        role: 'assistant',
+        content: 'done',
+        timestamp: 1,
+        agentAttemptId: 'attempt-2',
+      }],
+    });
+
+    expect(applyFinalizeAgentAttempt(session, 'attempt-2').messages[0])
+      .not.toHaveProperty('agentAttemptId');
   });
 });
 

--- a/src/hooks/useAgentRunner.ts
+++ b/src/hooks/useAgentRunner.ts
@@ -11,6 +11,7 @@ import { getActiveModelConfig } from '../services/llm-config';
 import { trackAgentRun, trackAgentError, trackAgentAbort } from '../lib/analytics';
 import { t, zh } from '../lib/i18n';
 import type { StrudelState } from '../services/strudel';
+import { isAbortError } from '../lib/errors';
 
 // ── Pure agent-turn logic (testable in isolation) ────────────────────────────
 //
@@ -82,12 +83,7 @@ export interface AgentTurnDeps {
 
 /** Distinguish a user-triggered abort from a genuine error. */
 export function isUserAbort(error: unknown, signal?: AbortSignal): boolean {
-  if (signal?.aborted) return true;
-  if (error instanceof DOMException && error.name === 'AbortError') return true;
-  if (error instanceof Error) {
-    return /abort(ed)?/i.test(error.name) || /request was aborted\.?/i.test(error.message);
-  }
-  return false;
+  return isAbortError(error, signal);
 }
 
 export async function runAgentTurn(input: AgentTurnInput, deps: AgentTurnDeps): Promise<void> {

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -14,6 +14,8 @@ export interface ChatMessage {
   code?: string;
   /** Immutable code boundary produced by this assistant turn. */
   revisionId?: string;
+  /** Present only while an LLM stream attempt is incomplete. */
+  agentAttemptId?: string;
   timestamp: number;
   // For role === 'progress':
   progressKind?: ProgressKind;

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -150,10 +150,18 @@ export function applyRefreshEmptySessionForReuse(s: Session, now: number): Sessi
   };
 }
 
-export function applyAppendAssistantDelta(s: Session, delta: string): Session {
+export function applyAppendAssistantDelta(
+  s: Session,
+  delta: string,
+  agentAttemptId?: string,
+): Session {
   const messages = [...s.messages];
   const last = messages[messages.length - 1];
-  if (last?.role === 'assistant' && !last.code) {
+  if (
+    last?.role === 'assistant'
+    && !last.code
+    && last.agentAttemptId === agentAttemptId
+  ) {
     messages[messages.length - 1] = { ...last, content: last.content + delta };
     return { ...s, messages };
   }
@@ -166,8 +174,60 @@ export function applyAppendAssistantDelta(s: Session, delta: string): Session {
         role: 'assistant' as const,
         content: delta,
         timestamp: Date.now(),
+        agentAttemptId,
       },
     ],
+  };
+}
+
+export function applyAppendProgressDelta(
+  s: Session,
+  delta: string,
+  kind: 'thinking' | 'reasoning',
+  agentAttemptId?: string,
+): Session {
+  const messages = [...s.messages];
+  const last = messages[messages.length - 1];
+  if (
+    last?.role === 'progress'
+    && last.progressKind === kind
+    && last.agentAttemptId === agentAttemptId
+  ) {
+    messages[messages.length - 1] = { ...last, content: last.content + delta };
+    return { ...s, messages };
+  }
+  return {
+    ...s,
+    messages: [
+      ...messages,
+      {
+        id: newMessageId(),
+        role: 'progress' as const,
+        content: delta,
+        timestamp: Date.now(),
+        progressKind: kind,
+        agentAttemptId,
+      },
+    ],
+  };
+}
+
+export function applyDiscardAgentAttempt(s: Session, attemptId: string): Session {
+  return {
+    ...s,
+    messages: s.messages.filter((message) => message.agentAttemptId !== attemptId),
+  };
+}
+
+export function applyFinalizeAgentAttempt(s: Session, attemptId: string): Session {
+  return {
+    ...s,
+    messages: s.messages.map((message) => {
+      if (message.agentAttemptId !== attemptId) return message;
+      const finalized = { ...message };
+      delete finalized.agentAttemptId;
+      return finalized;
+    }),
   };
 }
 
@@ -366,47 +426,50 @@ export function useSessions() {
 
   // Stream-append progress text: if the last message is already the same progress kind, append in-place; otherwise create a new one
   const appendToLastProgress = useCallback(
-    (delta: string, kind: 'thinking' | 'reasoning', sessionId?: string): void => {
+    (
+      delta: string,
+      kind: 'thinking' | 'reasoning',
+      sessionId?: string,
+      agentAttemptId?: string,
+    ): void => {
       const apply = getApply(sessionId);
-      apply((s) => {
-        const messages = [...s.messages];
-        const last = messages[messages.length - 1];
-        if (last?.role === 'progress' && last.progressKind === kind) {
-          messages[messages.length - 1] = { ...last, content: last.content + delta };
-          return { ...s, messages };
-        }
-        return {
-          ...s,
-          messages: [
-            ...messages,
-            {
-              id: newMessageId(),
-              role: 'progress' as const,
-              content: delta,
-              timestamp: Date.now(),
-              progressKind: kind,
-            },
-          ],
-        };
-      });
+      apply((s) => applyAppendProgressDelta(s, delta, kind, agentAttemptId));
     },
     [getApply]
   );
 
   const appendToLastThinking = useCallback(
-    (delta: string, sessionId?: string): void => appendToLastProgress(delta, 'thinking', sessionId),
+    (delta: string, sessionId?: string, agentAttemptId?: string): void =>
+      appendToLastProgress(delta, 'thinking', sessionId, agentAttemptId),
     [appendToLastProgress]
   );
 
   const appendToLastReasoning = useCallback(
-    (delta: string, sessionId?: string): void => appendToLastProgress(delta, 'reasoning', sessionId),
+    (delta: string, sessionId?: string, agentAttemptId?: string): void =>
+      appendToLastProgress(delta, 'reasoning', sessionId, agentAttemptId),
     [appendToLastProgress]
   );
 
   const appendToLastAssistant = useCallback(
-    (delta: string, sessionId?: string): void => {
+    (delta: string, sessionId?: string, agentAttemptId?: string): void => {
       const apply = getApply(sessionId);
-      apply((s) => applyAppendAssistantDelta(s, delta));
+      apply((s) => applyAppendAssistantDelta(s, delta, agentAttemptId));
+    },
+    [getApply]
+  );
+
+  const discardAgentAttempt = useCallback(
+    (attemptId: string, sessionId?: string): void => {
+      const apply = getApply(sessionId);
+      apply((s) => applyDiscardAgentAttempt(s, attemptId));
+    },
+    [getApply]
+  );
+
+  const finalizeAgentAttempt = useCallback(
+    (attemptId: string, sessionId?: string): void => {
+      const apply = getApply(sessionId);
+      apply((s) => applyFinalizeAgentAttempt(s, attemptId));
     },
     [getApply]
   );
@@ -674,6 +737,8 @@ export function useSessions() {
     appendToLastThinking,
     appendToLastReasoning,
     appendToLastAssistant,
+    discardAgentAttempt,
+    finalizeAgentAttempt,
     finalizeLastAssistantMessage,
     setCurrentCode,
     newSession,

--- a/src/lib/__tests__/agent-progress-handler.test.ts
+++ b/src/lib/__tests__/agent-progress-handler.test.ts
@@ -8,6 +8,8 @@ function makeSessions() {
     appendToLastAssistant: vi.fn(),
     appendToLastThinking: vi.fn(),
     appendToLastReasoning: vi.fn(),
+    discardAgentAttempt: vi.fn(),
+    finalizeAgentAttempt: vi.fn(),
   };
 }
 
@@ -16,9 +18,14 @@ describe('createAgentProgressHandler', () => {
     const sessions = makeSessions();
     const handle = createAgentProgressHandler(sessions, 'S1');
 
-    handle({ kind: 'assistant_reply_delta', delta: '你好，很高兴遇见你。' });
+    handle({
+      kind: 'assistant_reply_delta',
+      delta: '你好，很高兴遇见你。',
+      attemptId: 'attempt-1',
+    });
 
-    expect(sessions.appendToLastAssistant).toHaveBeenCalledWith('你好，很高兴遇见你。', 'S1');
+    expect(sessions.appendToLastAssistant)
+      .toHaveBeenCalledWith('你好，很高兴遇见你。', 'S1', 'attempt-1');
     expect(sessions.appendToLastThinking).not.toHaveBeenCalled();
   });
 
@@ -26,10 +33,22 @@ describe('createAgentProgressHandler', () => {
     const sessions = makeSessions();
     const handle = createAgentProgressHandler(sessions, 'S1');
 
-    handle({ kind: 'assistant_text_delta', delta: '先加一条贝斯线' });
+    handle({
+      kind: 'assistant_text_delta',
+      delta: '先加一条贝斯线',
+      attemptId: 'attempt-1',
+    });
+    handle({
+      kind: 'reasoning_delta',
+      delta: '分析节奏',
+      attemptId: 'attempt-1',
+    });
     handle({ kind: 'assistant_text', text: '让低音更有呼吸。' });
 
-    expect(sessions.appendToLastThinking).toHaveBeenCalledWith('先加一条贝斯线', 'S1');
+    expect(sessions.appendToLastThinking)
+      .toHaveBeenCalledWith('先加一条贝斯线', 'S1', 'attempt-1');
+    expect(sessions.appendToLastReasoning)
+      .toHaveBeenCalledWith('分析节奏', 'S1', 'attempt-1');
     expect(sessions.addProgress).toHaveBeenCalledWith(
       'thinking',
       '让低音更有呼吸。',
@@ -54,5 +73,16 @@ describe('createAgentProgressHandler', () => {
       expect.any(String),
       { toolName: 'setCode', sessionId: 'S1' },
     );
+  });
+
+  it('discards failed stream attempts and finalizes successful ones', () => {
+    const sessions = makeSessions();
+    const handle = createAgentProgressHandler(sessions, 'S1');
+
+    handle({ kind: 'request_attempt_discarded', attemptId: 'attempt-1' });
+    handle({ kind: 'request_attempt_succeeded', attemptId: 'attempt-2' });
+
+    expect(sessions.discardAgentAttempt).toHaveBeenCalledWith('attempt-1', 'S1');
+    expect(sessions.finalizeAgentAttempt).toHaveBeenCalledWith('attempt-2', 'S1');
   });
 });

--- a/src/lib/__tests__/errors.test.ts
+++ b/src/lib/__tests__/errors.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  getErrorStatus,
+  getRetryDelayMs,
+  isAbortError,
+  isRetryableRequestError,
+  waitForRetryDelay,
+} from '../errors';
+
+describe('request retry errors', () => {
+  it.each([408, 429, 500, 503])('retries HTTP %s', (status) => {
+    const error = Object.assign(new Error('request failed'), { status });
+
+    expect(isRetryableRequestError(error)).toBe(true);
+    expect(getErrorStatus(error)).toBe(status);
+  });
+
+  it.each([400, 401, 403, 404, 422])('does not retry HTTP %s', (status) => {
+    const error = Object.assign(new Error('request failed'), { status });
+
+    expect(isRetryableRequestError(error)).toBe(false);
+  });
+
+  it('retries browser and SDK connection failures', () => {
+    const sdkError = Object.assign(new Error('Connection closed'), {
+      name: 'APIConnectionError',
+    });
+
+    expect(isRetryableRequestError(new TypeError('network error'))).toBe(true);
+    expect(isRetryableRequestError(sdkError)).toBe(true);
+  });
+
+  it('retries empty responses but not unrelated errors', () => {
+    const emptyResponse = Object.assign(new Error('empty'), {
+      name: 'EmptyAgentResponseError',
+    });
+
+    expect(isRetryableRequestError(emptyResponse)).toBe(true);
+    expect(isRetryableRequestError(new Error('invalid local state'))).toBe(false);
+  });
+
+  it('never retries an abort', () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    expect(isAbortError(controller.signal.reason, controller.signal)).toBe(true);
+    expect(isRetryableRequestError(controller.signal.reason, controller.signal)).toBe(false);
+  });
+});
+
+describe('request retry delay', () => {
+  it('uses fixed bases plus a 0-250ms jitter', () => {
+    expect(getRetryDelayMs(1, () => 0)).toBe(500);
+    expect(getRetryDelayMs(1, () => 0.9999)).toBe(750);
+    expect(getRetryDelayMs(2, () => 0)).toBe(1500);
+    expect(getRetryDelayMs(2, () => 0.9999)).toBe(1750);
+  });
+
+  it('can be aborted while waiting', async () => {
+    vi.useFakeTimers();
+    try {
+      const controller = new AbortController();
+      const waiting = waitForRetryDelay(500, controller.signal);
+
+      controller.abort();
+
+      await expect(waiting).rejects.toMatchObject({ name: 'AbortError' });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/lib/agent-progress-handler.ts
+++ b/src/lib/agent-progress-handler.ts
@@ -4,7 +4,12 @@ import { t } from './i18n';
 
 type AgentProgressSessions = Pick<
   ReturnType<typeof useSessions>,
-  'addProgress' | 'appendToLastAssistant' | 'appendToLastThinking' | 'appendToLastReasoning'
+  | 'addProgress'
+  | 'appendToLastAssistant'
+  | 'appendToLastThinking'
+  | 'appendToLastReasoning'
+  | 'discardAgentAttempt'
+  | 'finalizeAgentAttempt'
 >;
 
 export function createAgentProgressHandler(
@@ -12,6 +17,14 @@ export function createAgentProgressHandler(
   sessionId: string,
 ): (event: ProgressEvent) => void {
   return (event) => {
+    if (event.kind === 'request_attempt_discarded') {
+      sessions.discardAgentAttempt(event.attemptId, sessionId);
+      return;
+    }
+    if (event.kind === 'request_attempt_succeeded') {
+      sessions.finalizeAgentAttempt(event.attemptId, sessionId);
+      return;
+    }
     if (event.kind === 'iteration') return;
     if (event.kind === 'tool_call') {
       if (event.name !== 'validate' && event.name !== 'commit') {
@@ -35,15 +48,15 @@ export function createAgentProgressHandler(
       return;
     }
     if (event.kind === 'reasoning_delta') {
-      sessions.appendToLastReasoning(event.delta, sessionId);
+      sessions.appendToLastReasoning(event.delta, sessionId, event.attemptId);
       return;
     }
     if (event.kind === 'assistant_text_delta') {
-      sessions.appendToLastThinking(event.delta, sessionId);
+      sessions.appendToLastThinking(event.delta, sessionId, event.attemptId);
       return;
     }
     if (event.kind === 'assistant_reply_delta') {
-      sessions.appendToLastAssistant(event.delta, sessionId);
+      sessions.appendToLastAssistant(event.delta, sessionId, event.attemptId);
       return;
     }
     if (event.kind === 'assistant_text') {

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -2,3 +2,72 @@
 export function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
+
+type ErrorWithStatus = { status?: unknown };
+
+export function getErrorStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+  const status = (error as ErrorWithStatus).status;
+  return typeof status === 'number' ? status : undefined;
+}
+
+export function isAbortError(error: unknown, signal?: AbortSignal): boolean {
+  if (signal?.aborted) return true;
+  if (
+    typeof DOMException !== 'undefined'
+    && error instanceof DOMException
+    && error.name === 'AbortError'
+  ) {
+    return true;
+  }
+  if (error instanceof Error) {
+    return /abort(ed)?/i.test(error.name)
+      || /request was aborted\.?/i.test(error.message);
+  }
+  return false;
+}
+
+export function isRetryableRequestError(error: unknown, signal?: AbortSignal): boolean {
+  if (isAbortError(error, signal)) return false;
+
+  const status = getErrorStatus(error);
+  if (status !== undefined) {
+    if (status === 408 || status === 429 || status >= 500) return true;
+    if (status >= 400 && status < 500) return false;
+  }
+
+  if (!(error instanceof Error)) return false;
+  if (error.name === 'EmptyAgentResponseError') return true;
+
+  return /(APIConnection|network|fetch|connection|socket|stream|terminated|closed|timeout|ECONN|EPIPE)/i
+    .test(`${error.name} ${error.message}`);
+}
+
+export function getRetryDelayMs(
+  retryNumber: 1 | 2,
+  random: () => number = Math.random,
+): number {
+  const base = retryNumber === 1 ? 500 : 1500;
+  return base + Math.floor(random() * 251);
+}
+
+function makeAbortError(): DOMException {
+  return new DOMException('Request was aborted.', 'AbortError');
+}
+
+export function waitForRetryDelay(delayMs: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.reject(makeAbortError());
+
+  return new Promise((resolve, reject) => {
+    let timer: ReturnType<typeof setTimeout>;
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(makeAbortError());
+    };
+    timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, delayMs);
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
+}

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -59,12 +59,11 @@ export function waitForRetryDelay(delayMs: number, signal?: AbortSignal): Promis
   if (signal?.aborted) return Promise.reject(makeAbortError());
 
   return new Promise((resolve, reject) => {
-    let timer: ReturnType<typeof setTimeout>;
-    const onAbort = () => {
+    function onAbort() {
       clearTimeout(timer);
       reject(makeAbortError());
-    };
-    timer = setTimeout(() => {
+    }
+    const timer = setTimeout(() => {
       signal?.removeEventListener('abort', onAbort);
       resolve();
     }, delayMs);


### PR DESCRIPTION
## Summary

- retry transient model requests up to two times with abortable 500 ms and 1500 ms backoff plus jitter
- retry network and stream failures, empty responses, HTTP 408/429, and 5xx while leaving other 4xx responses non-retryable
- tag streamed text and reasoning by request attempt so partial output is removed before retrying
- keep tool execution outside the retry boundary so a failed partial stream cannot duplicate tool calls
- log bounded retry diagnostics in `console.warn` and retain the existing final error message and manual retry action

## Root cause

The previous fix made empty and failed responses visible, but a transient connection close after HTTP 200 still ended the entire agent turn. Because text and reasoning are streamed directly into the session, retrying after a partial response also required an explicit rollback boundary to prevent duplicated content.

## User impact

Transient network failures now recover automatically without rerunning the whole user turn. If a stream disconnects after returning partial content, that failed content is removed and only the current model request is retried. After two unsuccessful retries, the UI still shows “网络发生错误，请重试” with the existing manual retry button.

## Validation

- `npm test` — 55 files, 480 tests passed
- `npm run build`
- `npm run lint` — 0 errors; 3 existing coverage warnings
- `git diff --check`
