### PR TITLE
feat: rework the mobile bottom chrome

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ import { isDemoMode, getActiveDemoSet } from './demo/demo-config';
 import ApiKeyModal from './components/ApiKeyModal';
 import { hasApiKeyConfigured } from './services/llm-config';
 import { resetClient } from './services/llm';
-import { HistoryIcon, PlusIcon } from './components/icons';
+import { HistoryIcon, PlayIcon, PlusIcon, StopIcon } from './components/icons';
 import { parseScore } from './agent/parser';
 import { useImportShare } from './hooks/useImportShare';
 import { useOddeNovaImport } from './hooks/useOddeNovaImport';
@@ -77,7 +77,6 @@ export default function App() {
     setHistoryOpen,
     drawerOpen,
     setDrawerOpen,
-    mobileFocusedArea,
     shouldLiftBottomBar,
     mobileDrawerHeight,
     handleChatFocusChange,
@@ -113,6 +112,19 @@ export default function App() {
       abortControllersRef.current.get(id)?.abort();
     }
   }, [sessions]);
+
+  // Mobile transport toggle next to the code pill. Mirrors CodePanel's footer
+  // play button, which mobile no longer renders.
+  const handleMobileTransportClick = useCallback(() => {
+    if (strudel.isPlaying) {
+      strudel.stop();
+    } else if (strudel.engineReady && strudel.code) {
+      void strudel.play();
+    }
+  }, [strudel]);
+  // Dimmed until there's something to play — but never while playing, or the
+  // stop action would become unreachable.
+  const mobileTransportDisabled = !strudel.isPlaying && (!strudel.engineReady || !strudel.code);
 
   const openPersonaModal = useCallback(() => {
     setShowPersonaModal(true);
@@ -170,8 +182,6 @@ export default function App() {
     ? (demoStep < activeSet.length ? [activeSet[demoStep].prompt] : [])
     : suggestions;
   const visibleSuggestions = demoSuggestions;
-  const showMobileCreateSuggestions =
-    !isLoading && visibleSuggestions.length > 0 && !isVideoMode && mobileFocusedArea !== 'code';
 
   // When the session switches, restore its code into the editor and stop audio
   useEffect(() => {
@@ -428,7 +438,10 @@ export default function App() {
         </div>
 
         {/* ── Conversation ── */}
-        <div className="flex-1 min-h-0 overflow-hidden">
+        {/* mb-3 keeps the stream from clipping flush against the rule below —
+            this is where messages get cut off as they scroll, so butting it
+            straight up to the line read as cramped. */}
+        <div className="flex-1 min-h-0 overflow-hidden mb-5">
           <ConversationView
             key={sessions.currentId ?? 'default'}
             messages={messages}
@@ -441,10 +454,24 @@ export default function App() {
         </div>
 
         {/* ── Code Drawer ── */}
+        {/* No border of its own: CodePanel already draws a full border, and a
+            border-t here would survive the 0-height collapsed state as a stray
+            line 6px below the rule. */}
         <div
-          className="shrink-0 overflow-hidden border-t border-border"
+          className="shrink-0 overflow-hidden"
           style={{
             height: mobileDrawerHeight,
+            // Lands CodePanel's bottom border exactly on the rule the bottom bar
+            // draws at -6px, so the two are the same row of pixels and read as
+            // one line. The border sits in the last 1px *inside* the drawer's
+            // box, so the box has to stop at -5, not -6.
+            //
+            // Constant, never animated: while this transitioned alongside height
+            // the border travelled from 0 to its resting place and showed as a
+            // second line for the length of the animation. Only height moves now,
+            // so the border stays pinned to the rule throughout. The conversation
+            // above is flex-1, so it gives up the 5px and the bar doesn't move.
+            marginBottom: 5,
             transition: 'height 0.3s cubic-bezier(0.4,0,0.2,1)',
           }}
         >
@@ -473,44 +500,58 @@ export default function App() {
 
         {/* ── Bottom Bar ── */}
         <div
-          className="relative shrink-0 px-3 pt-3 border-t border-border"
+          className="relative shrink-0 px-3 pt-3"
           style={{
             paddingBottom: 'max(12px, env(safe-area-inset-bottom))',
             transform: shouldLiftBottomBar ? `translateY(-${keyboardHeight}px)` : undefined,
             transition: 'transform 0.3s ease-out',
           }}
         >
-          {/* Code pill toggle — rides on the border-t line */}
-          <div className="absolute top-0 left-1/2 -translate-x-1/2 -translate-y-1/2">
+          {/* The rule the row below straddles, drawn 6px above this bar rather
+              than as its border-t so it lands on the row's centre line in both
+              drawer states. Kept inside the bar so it still rides along when the
+              keyboard lifts it; a sibling of the drawer would stay behind. */}
+          <div className="absolute -top-1.5 left-0 right-0 border-t border-border" />
+
+          {/* Transport and code pill both ride the rule above, positioned
+              independently: the transport flush left, the pill centred in the
+              bar. Both are 28px tall so they straddle the rule and hide the
+              stretch behind them with their own background. The transport lives
+              here rather than in CodePanel's footer so it stays reachable
+              whether or not the code drawer is open.
+
+              Only the pill is centred; the transport hangs off its left edge via
+              right-full rather than an offset of its own, so the 20px gap holds
+              when the label swaps between 查看代码 / 收起代码 and changes width. */}
+          <div className="absolute -top-1.5 left-1/2 -translate-x-1/2 -translate-y-1/2 h-7">
+            <button
+              onClick={handleMobileTransportClick}
+              disabled={mobileTransportDisabled}
+              // Dimmed by darkening the glyph itself, not by opacity: the icons
+              // fill from currentColor, so only the triangle/square goes down in
+              // brightness while the ring and background stay put.
+              className={`absolute right-full top-0 mr-3 flex w-7 h-7 items-center justify-center rounded-full border border-border bg-bg-primary disabled:cursor-not-allowed ${
+                mobileTransportDisabled ? 'text-[#591C06]' : 'text-[#B2370C]'
+              }`}
+              aria-label={strudel.isPlaying ? t('stop') : t('play')}
+              title={strudel.isPlaying ? t('stop') : t('play')}
+            >
+              {/* Stop renders smaller: Square fills its viewBox while Play's
+                  triangle is narrower, so equal sizes look unbalanced */}
+              {strudel.isPlaying ? <StopIcon size={12} /> : <PlayIcon size={14} />}
+            </button>
             <button
               onClick={() => setDrawerOpen((v) => !v)}
-              className="rounded-full border border-border bg-bg-primary px-4 py-1 text-[11px] text-text-secondary hover:text-text-primary transition-colors"
+              className="flex h-7 items-center rounded-full border border-border bg-bg-primary px-4 text-[12px] text-text-secondary hover:text-text-primary transition-colors"
             >
               {drawerOpen ? t('collapseCode') : t('viewCode')}
             </button>
           </div>
 
-          {/* Suggestion chips — horizontal scroll. Desktop rotates through the full
-              set as placeholder hints; mobile shows just two quick-action buttons. */}
-          {showMobileCreateSuggestions && (
-            <div className="suggestion-chips flex overflow-x-auto gap-2 pb-2 mt-3 no-scrollbar">
-              {visibleSuggestions.slice(0, 2).map((s) => (
-                <button
-                  key={s}
-                  type="button"
-                  onClick={() => handleInstruction(s)}
-                  disabled={strudel.engineStatus !== 'ready'}
-                  className="rounded-lg bg-transparent border border-border px-3 py-1.5 text-[11px] text-[#cccccc] whitespace-nowrap shrink-0 transition hover:border-accent/50 hover:text-text-primary disabled:opacity-40 disabled:cursor-not-allowed"
-                  style={{ fontFamily: 'system-ui, -apple-system, sans-serif' }}
-                >
-                  {s}
-                </button>
-              ))}
-            </div>
-          )}
-
-          {/* Input */}
-          <div className={showMobileCreateSuggestions ? '' : 'mt-3'}>
+          {/* Input. Suggestions ride inside it as the animated placeholder, same
+              as desktop — mobile adopts one by focusing the field rather than
+              with Tab, so no separate chip row. */}
+          <div className="mt-3">
             <ChatInput
               isLoading={isLoading}
               engineReady={strudel.engineReady}
@@ -521,6 +562,8 @@ export default function App() {
               prefill={rollbackPrefill}
               focusTrigger={inputFocusTrigger}
               onFocusChange={handleChatFocusChange}
+              suggestions={isVideoMode ? [] : visibleSuggestions}
+              isVideoMode={isVideoMode}
             />
           </div>
         </div>

--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -4,6 +4,7 @@ import type { TokenStats } from '../hooks/useSessions';
 import { t } from '../lib/i18n';
 import { checkAirJellyAvailable } from '../services/airjelly';
 import { isDemoMode } from '../demo/demo-config';
+import { useIsMobile } from '../hooks/useIsMobile';
 
 // Split text into typewriter units: CJK (and fullwidth punctuation) reveal
 // character by character, latin script word by word (a run of non-CJK,
@@ -67,6 +68,9 @@ export default function ChatInput({
 }: ChatInputProps) {
   const [text, setText] = useState('');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  // Mobile has no Tab key, so the suggestion is adopted by focusing the field
+  // instead, and the "press Tab" hint has nothing to point at.
+  const isMobile = useIsMobile();
 
   // AirJelly reachability, checked once on mount — same gating the removed
   // mood button used: Windows is excluded (AirJelly Desktop doesn't support
@@ -188,10 +192,20 @@ export default function ChatInput({
     doSubmit();
   };
 
+  // What Tab does on desktop. Adopts the whole suggestion, not just the part
+  // typed out so far, so a mid-reveal trigger doesn't yield half a sentence.
+  const adoptSuggestion = () => {
+    if (suggestionActive && currentSuggestion) setText(currentSuggestion);
+  };
+
   const handleCardClick = (e: React.MouseEvent<HTMLFormElement>) => {
     const target = e.target as HTMLElement;
     if (target.closest('button')) return;
     textareaRef.current?.focus();
+    // Keyed to the tap on this card rather than to onFocus: focus also arrives
+    // programmatically (mount's focusTrigger, rollback prefill, replay), and
+    // those must not adopt the suggestion.
+    if (isMobile) adoptSuggestion();
   };
 
   const inputDisabled = (isLoading || moodPending) && replayValue === undefined;
@@ -224,9 +238,10 @@ export default function ChatInput({
             onBlur={() => onFocusChange?.(false)}
             onKeyDown={(e) => {
               if (replayValue !== undefined) return;
+              // Guarded so Tab still moves focus out when there's nothing to adopt.
               if (e.key === 'Tab' && !e.shiftKey && suggestionActive && currentSuggestion) {
                 e.preventDefault();
-                setText(currentSuggestion);
+                adoptSuggestion();
                 return;
               }
               if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
@@ -244,7 +259,10 @@ export default function ChatInput({
           {/* Rotating suggestion shown in place of the native placeholder
               (which can't animate or carry a styled hint). The text types
               out unit by unit. Mirrors the textarea's own padding exactly;
-              pointer-events-none so clicks focus the input. */}
+              pointer-events-none so clicks focus the input. Type scale tracks
+              the textarea's, including its 16px on mobile — that size is there
+              to stop iOS auto-zoom on focus and can't be lowered, so the
+              overlay matches it to avoid a jump when a suggestion is adopted. */}
           {suggestionActive && (
             <div className="pointer-events-none absolute left-4 top-0 right-5 bottom-2 overflow-hidden line-clamp-3 text-base md:text-sm text-[#666666]">
               {/* Only the suggestion text blurs/fades between rotations — blur
@@ -287,7 +305,7 @@ export default function ChatInput({
                   </button>
                 )}
               </div>
-            ) : suggestionActive ? (
+            ) : suggestionActive && !isMobile ? (
               <div className="pointer-events-none text-[12px] text-[#666666]">{t('tabToFill')}</div>
             ) : null}
           </div>

--- a/src/components/CodePanel.tsx
+++ b/src/components/CodePanel.tsx
@@ -116,74 +116,6 @@ function SliderColumn({
   );
 }
 
-interface MobileSliderButtonProps {
-  label: string;
-  displayValue: string;
-  borderRight?: boolean;
-  onClick: () => void;
-}
-
-function MobileSliderButton({ label, displayValue, borderRight, onClick }: MobileSliderButtonProps) {
-  return (
-    <button
-      className="flex-1 min-w-0 flex flex-col items-center justify-center py-[10px] gap-[2px]"
-      style={borderRight ? { borderRight: '1px solid #323232' } : undefined}
-      onClick={onClick}
-    >
-      <span className="text-[11px] text-white/50 select-none">{label}</span>
-      <span className="text-[14px] text-white/90 select-none">{displayValue}</span>
-    </button>
-  );
-}
-
-interface MobileSliderConfig {
-  label: string;
-  value: number;
-  min: number;
-  max: number;
-  step: number;
-  formatValue: (v: number) => string;
-  onChange: (v: number) => void;
-}
-
-interface MobileSliderSheetProps {
-  activeSlider: 'volume' | 'bpm' | 'lpf' | null;
-  configs: Record<'volume' | 'bpm' | 'lpf', MobileSliderConfig>;
-  onClose: () => void;
-}
-
-function MobileSliderSheet({ activeSlider, configs, onClose }: MobileSliderSheetProps) {
-  if (activeSlider === null) return null;
-  const config = configs[activeSlider];
-  const pct = (config.value - config.min) / (config.max - config.min);
-
-  return (
-    <div className="fixed inset-0 z-50" onClick={onClose}>
-      <div className="absolute inset-0 bg-black/50" />
-      <div
-        className="absolute bottom-0 left-0 right-0 bg-[#111] border-t border-[#323232] px-6 py-6"
-        style={{ fontFamily: "'ABeeZee', monospace" }}
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex justify-between items-baseline mb-4">
-          <span className="text-[14px] text-white/60">{config.label}</span>
-          <span className="text-[24px] text-white font-light">{config.formatValue(config.value)}</span>
-        </div>
-        <input
-          type="range"
-          min={config.min}
-          max={config.max}
-          step={config.step}
-          value={config.value}
-          onChange={(e) => config.onChange(Number(e.target.value))}
-          className="aj-slider w-full"
-          style={{ height: '24px', ['--fill-pct' as string]: `${pct * 100}%` }}
-        />
-      </div>
-    </div>
-  );
-}
-
 export default function CodePanel({
   error,
   isPlaying,
@@ -213,7 +145,6 @@ export default function CodePanel({
   const bpmFromSlider = useRef(false);
 
   const isMobile = useIsMobile();
-  const [activeSlider, setActiveSlider] = useState<'volume' | 'bpm' | 'lpf' | null>(null);
 
   const handleExport = async (params: { filename: string; beginCycle: number; endCycle: number; sampleRate: number }) => {
     const ok = await onExport(params);
@@ -221,30 +152,6 @@ export default function CodePanel({
     await strudelService.setMasterVolume(volume);
     await strudelService.setMasterLPF(lpfSliderToHz(lpf));
     return ok;
-  };
-
-  const sliderConfigs: Record<'volume' | 'bpm' | 'lpf', MobileSliderConfig> = {
-    volume: {
-      label: 'Volume',
-      value: volume,
-      min: 0, max: 1, step: 0.01,
-      formatValue: (v) => `${Math.round(v * 100)}%`,
-      onChange: (v) => { setVolume(v); void strudelService.setMasterVolume(v); },
-    },
-    bpm: {
-      label: 'BPM',
-      value: bpm,
-      min: 60, max: 240, step: 1,
-      formatValue: (v) => `${v}`,
-      onChange: (v) => { setBpm(v); bpmFromSlider.current = true; strudelService.setTempo(v); bpmFromSlider.current = false; },
-    },
-    lpf: {
-      label: 'LPF',
-      value: lpf,
-      min: 0, max: 1, step: 0.005,
-      formatValue: formatLpf,
-      onChange: (v) => { setLpf(v); void strudelService.setMasterLPF(lpfSliderToHz(v)); },
-    },
   };
 
   useEffect(() => {
@@ -257,6 +164,8 @@ export default function CodePanel({
 
   useEffect(() => {
     strudelService.setAutocompletionEnabled(!isMobile);
+    // Wrap instead of scrolling sideways in the narrow mobile drawer.
+    strudelService.setLineWrappingEnabled(isMobile);
   }, [isMobile]);
 
   // Demo mode plays at a quiet 10% by default; the master engine otherwise
@@ -412,42 +321,36 @@ export default function CodePanel({
         topActionsContainer.current,
       )}
 
-      {/* Footer — play button + sliders */}
-      <div
-        className="shrink-0 flex items-stretch border-t"
-        style={{ background: '#000', borderColor: '#323232', fontFamily: "'ABeeZee', monospace" }}
-      >
-        {/* Play button, width matches .cm-gutters */}
+      {/* Footer — play button + sliders. Desktop only: on mobile the drawer shows
+          nothing but code, and transport lives next to App's code-pill toggle. */}
+      {!isMobile && (
         <div
-          className="flex items-center justify-center py-[6px]"
-          style={{
-            width: gutterWidth || undefined,
-            minWidth: gutterWidth || undefined,
-            borderRight: gutterWidth ? '1px solid #323232' : undefined,
-          }}
+          className="shrink-0 flex items-stretch border-t"
+          style={{ background: '#000', borderColor: '#323232', fontFamily: "'ABeeZee', monospace" }}
         >
-          <button
-            onClick={handlePlayClick}
-            disabled={!engineReady && !isPlaying}
-            className={`flex items-center justify-center w-9 h-9 transition-opacity text-[#B2370C] ${
-              isPlaying ? 'hover:opacity-70' : 'hover:opacity-70 disabled:opacity-30 disabled:cursor-not-allowed'
-            }`}
-            title={isPlaying ? t('stop') : t('play')}
+          {/* Play button, width matches .cm-gutters */}
+          <div
+            className="flex items-center justify-center py-[6px]"
+            style={{
+              width: gutterWidth || undefined,
+              minWidth: gutterWidth || undefined,
+              borderRight: gutterWidth ? '1px solid #323232' : undefined,
+            }}
           >
-            {/* Stop renders smaller: Square fills its viewBox (18×18) while
-                Play's triangle is ~14×18, so equal sizes look unbalanced */}
-            {isPlaying ? <StopIcon size={30} /> : <PlayIcon size={36} />}
-          </button>
-        </div>
+            <button
+              onClick={handlePlayClick}
+              disabled={!engineReady && !isPlaying}
+              className={`flex items-center justify-center w-9 h-9 transition-opacity text-[#B2370C] ${
+                isPlaying ? 'hover:opacity-70' : 'hover:opacity-70 disabled:opacity-30 disabled:cursor-not-allowed'
+              }`}
+              title={isPlaying ? t('stop') : t('play')}
+            >
+              {/* Stop renders smaller: Square fills its viewBox (18×18) while
+                  Play's triangle is ~14×18, so equal sizes look unbalanced */}
+              {isPlaying ? <StopIcon size={30} /> : <PlayIcon size={36} />}
+            </button>
+          </div>
 
-        {isMobile ? (
-          <MobileSliderButton
-            label="Volume"
-            displayValue={`${Math.round(volume * 100)}%`}
-            borderRight
-            onClick={() => setActiveSlider('volume')}
-          />
-        ) : (
           <SliderColumn
             label="Volume"
             sliderKey="volume"
@@ -464,16 +367,7 @@ export default function CodePanel({
             onTooltip={setTooltip}
             borderRight
           />
-        )}
 
-        {isMobile ? (
-          <MobileSliderButton
-            label="BPM"
-            displayValue={`${bpm}`}
-            borderRight
-            onClick={() => setActiveSlider('bpm')}
-          />
-        ) : (
           <SliderColumn
             label="BPM"
             sliderKey="bpm"
@@ -492,15 +386,7 @@ export default function CodePanel({
             onTooltip={setTooltip}
             borderRight
           />
-        )}
 
-        {isMobile ? (
-          <MobileSliderButton
-            label="LPF"
-            displayValue={formatLpf(lpf)}
-            onClick={() => setActiveSlider('lpf')}
-          />
-        ) : (
           <SliderColumn
             label="LPF"
             sliderKey="lpf"
@@ -516,14 +402,7 @@ export default function CodePanel({
             }}
             onTooltip={setTooltip}
           />
-        )}
-      </div>
-      {isMobile && (
-        <MobileSliderSheet
-          activeSlider={activeSlider}
-          configs={sliderConfigs}
-          onClose={() => setActiveSlider(null)}
-        />
+        </div>
       )}
     </div>
   );

--- a/src/components/__tests__/CodePanel.test.tsx
+++ b/src/components/__tests__/CodePanel.test.tsx
@@ -12,6 +12,7 @@ vi.mock('../../services/strudel', () => ({
     setMasterVolume: vi.fn().mockResolvedValue(undefined),
     setTempo: vi.fn(),
     setAutocompletionEnabled: vi.fn(),
+    setLineWrappingEnabled: vi.fn(),
   },
 }));
 
@@ -152,5 +153,31 @@ describe('CodePanel editor focus reporting', () => {
 
     act(() => setMobile(false));
     expect(strudelService.setAutocompletionEnabled).toHaveBeenLastCalledWith(true);
+  });
+
+  it('wraps long lines on mobile but not on desktop', () => {
+    installMatchMedia(true);
+    const { root } = renderCodePanel();
+    roots.push(root);
+
+    expect(strudelService.setLineWrappingEnabled).toHaveBeenCalledWith(true);
+
+    installMatchMedia(false);
+    const second = renderCodePanel();
+    roots.push(second.root);
+
+    expect(strudelService.setLineWrappingEnabled).toHaveBeenLastCalledWith(false);
+  });
+
+  it('updates line wrapping when the layout crosses the mobile breakpoint', () => {
+    const setMobile = installMatchMedia(false);
+    const { root } = renderCodePanel();
+    roots.push(root);
+
+    act(() => setMobile(true));
+    expect(strudelService.setLineWrappingEnabled).toHaveBeenLastCalledWith(true);
+
+    act(() => setMobile(false));
+    expect(strudelService.setLineWrappingEnabled).toHaveBeenLastCalledWith(false);
   });
 });

--- a/src/index.css
+++ b/src/index.css
@@ -318,6 +318,34 @@ body {
   .cm-editor .cm-lineNumbers .cm-gutterElement { font-size: 16px !important; }
 }
 
+/* Narrow the gutter below the mobile breakpoint (matches useIsMobile, i.e. the
+   widths where the editor lives in the drawer): the desktop 72px costs too much
+   of the line. 32px of content still fits a 3-digit number at the 16px above. */
+@media (max-width: 768px) {
+  .cm-editor .cm-lineNumbers {
+    width: 44px !important;
+    min-width: 44px !important;
+  }
+
+  .cm-editor .cm-lineNumbers .cm-gutterElement {
+    width: 44px !important;
+    padding-left: 6px !important;
+    padding-right: 6px !important;
+  }
+
+  /* Hanging indent for wrapped lines (wrapping itself is turned on via
+     StrudelMirror's setLineWrappingEnabled, see CodePanel). CodeMirror starts a
+     continuation row at column 0, which reads as a new statement; the negative
+     text-indent pulls the *first* row back out by the same amount the padding
+     pushes the block in, so the first row lands where it always did and only
+     continuation rows are inset. Padding keeps CodeMirror's own 6px on
+     .cm-line, otherwise the caret sits flush against the gutter border. */
+  .cm-editor .cm-line {
+    padding-left: calc(6px + 3ch);
+    text-indent: -3ch;
+  }
+}
+
 /* Strudel full-page visualizer canvas (pianoroll, scope等) 浮于编辑器上层，pointer-events:none 不影响操作 */
 /* z-index 生效依赖 strudel 在 JS 中内联设置的 position:fixed（见 @strudel/draw draw.mjs getDrawContext）*/
 canvas#test-canvas {

--- a/src/presentation.css
+++ b/src/presentation.css
@@ -23,7 +23,3 @@ body {
   overflow: hidden;
 }
 
-.suggestion-chips {
-  display: none !important;
-}
-

--- a/src/services/__tests__/strudel.test.ts
+++ b/src/services/__tests__/strudel.test.ts
@@ -295,6 +295,7 @@ describe('StrudelService editor preferences', () => {
         setCode = vi.fn();
         evaluate = vi.fn(async () => {});
         setAutocompletionEnabled = setAutocompletionEnabled;
+        setLineWrappingEnabled = vi.fn();
         changeSetting = vi.fn();
       },
     }));
@@ -321,6 +322,7 @@ describe('StrudelService editor preferences', () => {
         setCode = vi.fn();
         evaluate = vi.fn(async () => {});
         setAutocompletionEnabled = vi.fn();
+        setLineWrappingEnabled = vi.fn();
         changeSetting = changeSetting;
       },
     }));

--- a/src/services/strudel.ts
+++ b/src/services/strudel.ts
@@ -17,6 +17,7 @@ interface StrudelMirrorType {
   repl: { setCode: (code: string) => void; stop: () => void; [key: string]: unknown };
   setCode: (code: string) => void;
   setAutocompletionEnabled: (enabled: boolean) => void;
+  setLineWrappingEnabled: (enabled: boolean) => void;
   changeSetting: (key: 'isTabIndentationEnabled', value: boolean) => void;
   evaluate: (autostart?: boolean) => Promise<void>;
 }
@@ -143,6 +144,7 @@ export class StrudelService {
   private editorInstance: StrudelMirrorType | null = null;
   private containerElement: HTMLElement | null = null;
   private autocompletionEnabled = false;
+  private lineWrappingEnabled = false;
   private isAudioInitialized = false;
   private isInitializing = false;
 
@@ -222,6 +224,11 @@ export class StrudelService {
   setAutocompletionEnabled(enabled: boolean): void {
     this.autocompletionEnabled = enabled;
     this.editorInstance?.setAutocompletionEnabled(enabled);
+  }
+
+  setLineWrappingEnabled(enabled: boolean): void {
+    this.lineWrappingEnabled = enabled;
+    this.editorInstance?.setLineWrappingEnabled(enabled);
   }
 
   private prebake = async (): Promise<void> => {
@@ -351,6 +358,7 @@ export class StrudelService {
       });
       this.editorInstance = editor;
       editor.setAutocompletionEnabled(this.autocompletionEnabled);
+      editor.setLineWrappingEnabled(this.lineWrappingEnabled);
       editor.changeSetting('isTabIndentationEnabled', true);
 
       // Sync REPL internal state with initial code


### PR DESCRIPTION
Move transport out of CodePanel's footer and onto the code-drawer toggle row, so playback stays reachable whether or not the drawer is open, and drop the footer on mobile entirely — the drawer is now just code. The mobile volume/BPM/LPF sheet went with it, since the footer was its only entry point.

Replace the mobile suggestion chips with the same animated placeholder carousel desktop uses. Mobile adopts a suggestion by tapping the input card rather than with Tab; keying that to the card click instead of onFocus keeps programmatic focus (mount, rollback prefill, replay) from adopting one, and the Tab hint is hidden where there is no Tab key.

In the drawer itself, narrow the gutter and turn on line wrapping via StrudelMirror's own setLineWrappingEnabled, with a hanging indent so continuation rows don't read as new statements.

Align the toggle row, the rule it straddles and the drawer's bottom edge on one line: the rule moves off the bottom bar's border-t into a lifted element inside it, so it tracks the bar when the keyboard raises it, and the drawer's bottom margin is constant so its border stays pinned to the rule instead of drifting across the open/close animation.