### PR TITLE
Switch official provider model to deepseek-v4-flash

### DIFF
--- a/src/services/__tests__/llm-config.test.ts
+++ b/src/services/__tests__/llm-config.test.ts
@@ -174,7 +174,7 @@ describe('getSelectedModel', () => {
 
   it('returns preset.model for official regardless of any stored override', () => {
     localStorage.setItem('vibe_model_official', 'whatever');
-    expect(getSelectedModel('official')).toBe('deepseek-v4-pro');
+    expect(getSelectedModel('official')).toBe('deepseek-v4-flash');
   });
 });
 

--- a/src/services/llm-config.ts
+++ b/src/services/llm-config.ts
@@ -71,7 +71,7 @@ export const PROVIDER_PRESETS: Record<ProviderType, ProviderPreset> = {
   official: {
     label: t('officialLabel'),
     baseURL: '/api/official/v1',
-    model: 'deepseek-v4-pro',
+    model: 'deepseek-v4-flash',
     protocol: 'openai',
   },
   glm: {


### PR DESCRIPTION
## Summary
- Changed the `official` provider preset's model from `deepseek-v4-pro` to `deepseek-v4-flash` in `src/services/llm-config.ts`
- Updated the matching unit test in `src/services/__tests__/llm-config.test.ts`

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.app.json`
- [x] `npx eslint src/services/llm-config.ts --max-warnings=0`
- [x] `npm test` (515 passed)