### PR TITLE
将 video/version0 加入僵尸分支清理的保护名单

### DIFF
--- a/.github/workflows/cleanup-zombie-branches.yml
+++ b/.github/workflows/cleanup-zombie-branches.yml
@@ -19,7 +19,9 @@ jobs:
         with:
           script: |
             // 保护分支（不删除）
-            const PROTECTED = new Set(['main', 'release_preview']);
+            // video/version0 固定指向录制 chapter-01 视频所用的 App 版本，
+            // 按设计长期停留在历史提交上，因此始终会满足"90 天无活动"的删除条件
+            const PROTECTED = new Set(['main', 'release_preview', 'video/version0']);
 
             const cutoff = new Date();
             cutoff.setDate(cutoff.getDate() - 90);


### PR DESCRIPTION
video/version0 固定指向录制 chapter-01 视频所用的 App 版本，按设计长期 停留在历史提交上，不会有新提交。清理任务以分支尖端提交日期判定活跃度，
因此这个分支必然会满足"90 天无活动"的删除条件而被清掉。