### PR TITLE
Preserve code revisions in shared sessions

### DIFF
--- a/src/components/TopActionBar.tsx
+++ b/src/components/TopActionBar.tsx
@@ -37,6 +37,7 @@ function ShareButton({ session, code, messages, disabled, variant = 'inline', on
         title,
         code: shareCode,
         messages: shareMessages,
+        revisions: session?.revisions,
         locale: zh ? 'zh-CN' : 'en',
       });
       const url = `${window.location.origin}/s/${shareId}`;

--- a/src/components/__tests__/TopActionBar.test.tsx
+++ b/src/components/__tests__/TopActionBar.test.tsx
@@ -135,6 +135,44 @@ describe('TopActionBar mobile menu', () => {
     });
   });
 
+  it('shares the code revisions referenced by conversation messages', async () => {
+    setDesktopViewport();
+    uploadShareMock.mockResolvedValueOnce('share123');
+    shareUrlMock.mockResolvedValueOnce('copied');
+    const revision = {
+      id: 'rev-1',
+      beforeCode: '',
+      afterCode: 's("bd")',
+      playbackStatus: 'played' as const,
+      createdAt: 1,
+    };
+    const session = makeSession({
+      code: 's("bd")',
+      messages: [{
+        id: 'm-1',
+        role: 'assistant',
+        content: '完成',
+        code: 's("bd")',
+        revisionId: revision.id,
+        timestamp: 1,
+      }],
+      revisions: [revision],
+    });
+    const { container, root } = renderShareBar(session);
+    roots.push(root);
+
+    const shareButton = Array.from(container.querySelectorAll<HTMLButtonElement>('button'))
+      .find((button) => button.textContent === 'Share');
+    await act(async () => {
+      shareButton?.click();
+    });
+
+    expect(uploadShareMock).toHaveBeenCalledWith(expect.objectContaining({
+      messages: session.messages,
+      revisions: [revision],
+    }));
+  });
+
   it.each([
     ['shared', 'native'],
     ['shown', 'prompt'],

--- a/src/hooks/__tests__/useSessions.test.ts
+++ b/src/hooks/__tests__/useSessions.test.ts
@@ -511,6 +511,94 @@ describe('useSessions', () => {
     expect(session.messages.at(-1)?.revisionId).toBe(session.revisions?.[0].id);
   });
 
+  it('restores referenced code revisions when importing a shared session', async () => {
+    const { root, getHook } = await renderUseSessions();
+    roots.push(root);
+    const referencedRevision = {
+      id: 'rev-1',
+      beforeCode: '',
+      afterCode: 's("bd")',
+      playbackStatus: 'played' as const,
+      createdAt: 1,
+    };
+    const unreferencedRevision = {
+      id: 'rev-stale',
+      beforeCode: 's("bd")',
+      afterCode: 's("sd")',
+      playbackStatus: 'played' as const,
+      createdAt: 2,
+    };
+
+    await act(async () => {
+      await getHook().importSession({
+        title: '分享的节奏',
+        code: 's("bd")',
+        messages: [{
+          id: 'msg-1',
+          role: 'assistant',
+          content: '完成',
+          code: 's("bd")',
+          revisionId: referencedRevision.id,
+          timestamp: 1,
+        }],
+        revisions: [referencedRevision, unreferencedRevision],
+      });
+    });
+
+    expect(getHook().currentSession?.revisions).toEqual([referencedRevision]);
+    expect(storageMocks.putSession).toHaveBeenLastCalledWith(
+      expect.objectContaining({ revisions: [referencedRevision] }),
+    );
+  });
+
+  it('reconstructs code revisions when importing a legacy share without revisions', async () => {
+    const { root, getHook } = await renderUseSessions();
+    roots.push(root);
+
+    await act(async () => {
+      await getHook().importSession({
+        title: '旧分享',
+        code: 's("sd")',
+        messages: [
+          {
+            id: 'msg-1',
+            role: 'assistant',
+            content: '第一版',
+            code: 's("bd")',
+            revisionId: 'rev-1',
+            timestamp: 1,
+          },
+          { id: 'msg-2', role: 'user', content: '换成军鼓', timestamp: 2 },
+          {
+            id: 'msg-3',
+            role: 'assistant',
+            content: '第二版',
+            code: 's("sd")',
+            revisionId: 'rev-2',
+            timestamp: 3,
+          },
+        ],
+      });
+    });
+
+    expect(getHook().currentSession?.revisions).toEqual([
+      {
+        id: 'rev-1',
+        beforeCode: '',
+        afterCode: 's("bd")',
+        playbackStatus: 'not_attempted',
+        createdAt: 1,
+      },
+      {
+        id: 'rev-2',
+        beforeCode: 's("bd")',
+        afterCode: 's("sd")',
+        playbackStatus: 'not_attempted',
+        createdAt: 3,
+      },
+    ]);
+  });
+
   it('keeps ordinary assistant messages revision-free', async () => {
     const { root, getHook } = await renderUseSessions();
     roots.push(root);

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -97,6 +97,30 @@ function revisionsReferencedBy(messages: ChatMessage[], revisions?: CodeRevision
   return revisions.filter((revision) => referenced.has(revision.id));
 }
 
+function importedRevisions(messages: ChatMessage[], revisions?: CodeRevision[]): CodeRevision[] | undefined {
+  if (revisions !== undefined) return revisionsReferencedBy(messages, revisions);
+
+  let beforeCode = '';
+  const reconstructed: CodeRevision[] = [];
+  const seen = new Set<string>();
+  for (const message of messages) {
+    if (message.role !== 'assistant' || message.code === undefined) continue;
+    if (message.revisionId && !seen.has(message.revisionId)) {
+      reconstructed.push({
+        id: message.revisionId,
+        beforeCode,
+        afterCode: message.code,
+        playbackStatus: 'not_attempted',
+        createdAt: message.timestamp,
+      });
+      seen.add(message.revisionId);
+    }
+    beforeCode = message.code;
+  }
+
+  return reconstructed.length > 0 ? reconstructed : undefined;
+}
+
 function inputModeReferencedBy(messages: ChatMessage[]): InputMode {
   return [...messages].reverse().find(
     (message) => message.role === 'assistant' && message.inputMode !== undefined,
@@ -592,7 +616,7 @@ export function useSessions() {
   );
 
   const importSession = useCallback(
-    async (payload: { title: string; code: string; messages: ChatMessage[] }): Promise<void> => {
+    async (payload: { title: string; code: string; messages: ChatMessage[]; revisions?: CodeRevision[] }): Promise<void> => {
       const id = newSessionId();
       const now = Date.now();
       const session: Session = {
@@ -600,6 +624,7 @@ export function useSessions() {
         title: `${payload.title}`,
         messages: payload.messages,
         code: payload.code,
+        revisions: importedRevisions(payload.messages, payload.revisions),
         createdAt: now,
         updatedAt: now,
       };

--- a/src/services/__tests__/share.test.ts
+++ b/src/services/__tests__/share.test.ts
@@ -17,6 +17,13 @@ describe('uploadShare', () => {
       title: 'My Session',
       code: 'note "c5"',
       messages: [],
+      revisions: [{
+        id: 'rev-1',
+        beforeCode: '',
+        afterCode: 'note "c5"',
+        playbackStatus: 'played',
+        createdAt: 1,
+      }],
       locale: 'zh-CN',
     });
 
@@ -30,6 +37,13 @@ describe('uploadShare', () => {
     expect(body.version).toBe(1);
     expect(body.title).toBe('My Session');
     expect(body.code).toBe('note "c5"');
+    expect(body.revisions).toEqual([{
+      id: 'rev-1',
+      beforeCode: '',
+      afterCode: 'note "c5"',
+      playbackStatus: 'played',
+      createdAt: 1,
+    }]);
     expect(body.locale).toBe('zh-CN');
     expect(typeof body.sharedAt).toBe('number');
     expect(shareId).toBe(mockShareId);

--- a/src/services/share.ts
+++ b/src/services/share.ts
@@ -1,4 +1,5 @@
 import type { ChatMessage } from '../hooks/useChat';
+import type { CodeRevision } from '../hooks/useSessions';
 
 export type ShareLocale = 'zh-CN' | 'en';
 
@@ -7,6 +8,7 @@ export interface SharePayload {
   title: string;
   code: string;
   messages: ChatMessage[];
+  revisions?: CodeRevision[];
   sharedAt: number;
   locale?: ShareLocale;
 }
@@ -15,6 +17,7 @@ interface UploadShareInput {
   title: string;
   code: string;
   messages: ChatMessage[];
+  revisions?: CodeRevision[];
   locale: ShareLocale;
 }
 
@@ -24,6 +27,7 @@ export async function uploadShare(input: UploadShareInput): Promise<string> {
     title: input.title,
     code: input.code,
     messages: input.messages,
+    revisions: input.revisions,
     sharedAt: Date.now(),
     locale: input.locale,
   };


### PR DESCRIPTION
## 摘要

- 在分享数据中携带会话代码修订记录
- 导入分享会话时仅恢复被消息引用的修订
- 为缺少修订记录的旧分享数据重建修订历史
- 增加分享、导入和兼容性测试

## 测试

- 已补充并覆盖相关组件、Hook 与分享服务测试