### PR TITLE
Add localized session titles to share-page metadata

### DIFF
--- a/api/share-page.ts
+++ b/api/share-page.ts
@@ -5,14 +5,15 @@ type ShareLocale = 'zh-CN' | 'en';
 
 interface SharePayload {
   locale?: ShareLocale;
+  title?: string;
 }
 
 const SHARE_TITLE = 'oddeNova | Vibe Your Music, Live';
 const SHARE_IMAGE = 'https://www.oddenova.com/oddenova-og.png?v=c1189f30';
 
 const SHARE_DESCRIPTIONS: Record<ShareLocale, string> = {
-  'zh-CN': '即兴 vibe 音乐，让灵感，自由发声',
-  en: 'Plain text → Rich music',
+  'zh-CN': 'oddeNova 即兴 vibe 音乐，让灵感，自由发声',
+  en: 'oddeNova Plain text → Rich music',
 };
 
 const FALLBACK_APP_SHELL = `<!doctype html>
@@ -61,18 +62,19 @@ function replaceMeta(html: string, selector: string, value: string): string {
   return html.replace(/<\/head>/i, `    <meta ${selector} content="${escaped}" />\n  </head>`);
 }
 
-function renderShareHtml(html: string, options: { locale?: ShareLocale; url: string }): string {
+function renderShareHtml(html: string, options: { locale?: ShareLocale; title?: string; url: string }): string {
   const locale = normalizeLocale(options.locale);
   const description = SHARE_DESCRIPTIONS[locale];
+  const title = options.title?.trim() || SHARE_TITLE;
 
   let out = html.replace(/<html\b[^>]*>/i, `<html lang="${locale}">`);
-  out = out.replace(/<title>.*?<\/title>/i, `<title>${SHARE_TITLE}</title>`);
+  out = out.replace(/<title>.*?<\/title>/i, `<title>${escapeHtmlAttr(title)}</title>`);
   out = replaceMeta(out, 'name="description"', description);
-  out = replaceMeta(out, 'property="og:title"', SHARE_TITLE);
+  out = replaceMeta(out, 'property="og:title"', title);
   out = replaceMeta(out, 'property="og:description"', description);
   out = replaceMeta(out, 'property="og:url"', options.url);
   out = replaceMeta(out, 'property="og:image"', SHARE_IMAGE);
-  out = replaceMeta(out, 'name="twitter:title"', SHARE_TITLE);
+  out = replaceMeta(out, 'name="twitter:title"', title);
   out = replaceMeta(out, 'name="twitter:description"', description);
   out = replaceMeta(out, 'name="twitter:image"', SHARE_IMAGE);
   return out;
@@ -96,10 +98,12 @@ async function sendShareHtml(
   res: VercelResponse,
   id: string,
   locale?: SharePayload['locale'],
+  title?: SharePayload['title'],
 ) {
   const origin = getRequestOrigin(req);
   const html = renderShareHtml(await fetchAppShell(origin), {
     locale,
+    title,
     url: `${origin}/s/${encodeURIComponent(id)}`,
   });
 
@@ -150,5 +154,5 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     return;
   }
 
-  await sendShareHtml(req, res, id, payload.locale);
+  await sendShareHtml(req, res, id, payload.locale, payload.title);
 }

--- a/src/services/__tests__/share-page-meta.test.ts
+++ b/src/services/__tests__/share-page-meta.test.ts
@@ -28,38 +28,44 @@ describe('renderShareHtml', () => {
   it('uses Chinese share metadata for zh-CN payloads', () => {
     const html = renderShareHtml(baseHtml, {
       locale: 'zh-CN',
+      title: '雨夜里的松弛 Lo-fi',
       url: 'https://oddenova.com/s/abc123',
     });
 
     expect(html).toContain('<html lang="zh-CN">');
-    expect(html).toContain('content="oddeNova | Vibe Your Music, Live"');
-    expect(html).toContain('content="即兴 vibe 音乐，让灵感，自由发声"');
+    expect(html).toContain('property="og:title" content="雨夜里的松弛 Lo-fi"');
+    expect(html).toContain('name="twitter:title" content="雨夜里的松弛 Lo-fi"');
+    expect(html).toContain('content="oddeNova 即兴 vibe 音乐，让灵感，自由发声"');
     expect(html).toContain('property="og:url" content="https://oddenova.com/s/abc123"');
     expect(html).toContain('property="og:image" content="https://www.oddenova.com/oddenova-og.png?v=c1189f30"');
     expect(html).toContain('name="twitter:image" content="https://www.oddenova.com/oddenova-og.png?v=c1189f30"');
-    expect(html).toContain('<title>oddeNova | Vibe Your Music, Live</title>');
+    expect(html).toContain('<title>雨夜里的松弛 Lo-fi</title>');
   });
 
   it('uses English share metadata for en payloads', () => {
     const html = renderShareHtml(baseHtml, {
       locale: 'en',
+      title: 'Rainy Night Lo-fi',
       url: 'https://oddenova.com/s/abc123',
     });
 
     expect(html).toContain('<html lang="en">');
-    expect(html).toContain('content="oddeNova | Vibe Your Music, Live"');
-    expect(html).toContain('name="description"\n      content="Plain text → Rich music"');
-    expect(html).toContain('property="og:description"\n      content="Plain text → Rich music"');
-    expect(html).toContain('name="twitter:description"\n      content="Plain text → Rich music"');
+    expect(html).toContain('property="og:title" content="Rainy Night Lo-fi"');
+    expect(html).toContain('name="twitter:title" content="Rainy Night Lo-fi"');
+    expect(html).toContain('name="description"\n      content="oddeNova Plain text → Rich music"');
+    expect(html).toContain('property="og:description"\n      content="oddeNova Plain text → Rich music"');
+    expect(html).toContain('name="twitter:description"\n      content="oddeNova Plain text → Rich music"');
     expect(html).toContain('property="og:url" content="https://oddenova.com/s/abc123"');
+    expect(html).toContain('<title>Rainy Night Lo-fi</title>');
   });
 
-  it('defaults old payloads without locale to Chinese metadata', () => {
+  it('uses the brand fallback title when share metadata has no title', () => {
     const html = renderShareHtml(baseHtml, {
       url: 'https://oddenova.com/s/old123',
     });
 
     expect(html).toContain('<html lang="zh-CN">');
-    expect(html).toContain('content="即兴 vibe 音乐，让灵感，自由发声"');
+    expect(html).toContain('property="og:title" content="oddeNova | Vibe Your Music, Live"');
+    expect(html).toContain('content="oddeNova 即兴 vibe 音乐，让灵感，自由发声"');
   });
 });

--- a/src/services/share-page-meta.ts
+++ b/src/services/share-page-meta.ts
@@ -4,12 +4,13 @@ const SHARE_TITLE = 'oddeNova | Vibe Your Music, Live';
 const SHARE_IMAGE = 'https://www.oddenova.com/oddenova-og.png?v=c1189f30';
 
 const SHARE_DESCRIPTIONS: Record<ShareLocale, string> = {
-  'zh-CN': '即兴 vibe 音乐，让灵感，自由发声',
-  en: 'Plain text → Rich music',
+  'zh-CN': 'oddeNova 即兴 vibe 音乐，让灵感，自由发声',
+  en: 'oddeNova Plain text → Rich music',
 };
 
 interface RenderShareHtmlOptions {
   locale?: ShareLocale;
+  title?: string;
   url: string;
 }
 
@@ -38,15 +39,16 @@ function replaceMeta(html: string, selector: string, value: string): string {
 export function renderShareHtml(html: string, options: RenderShareHtmlOptions): string {
   const locale = normalizeLocale(options.locale);
   const description = SHARE_DESCRIPTIONS[locale];
+  const title = options.title?.trim() || SHARE_TITLE;
 
   let out = html.replace(/<html\b[^>]*>/i, `<html lang="${locale}">`);
-  out = out.replace(/<title>.*?<\/title>/i, `<title>${SHARE_TITLE}</title>`);
+  out = out.replace(/<title>.*?<\/title>/i, `<title>${escapeHtmlAttr(title)}</title>`);
   out = replaceMeta(out, 'name="description"', description);
-  out = replaceMeta(out, 'property="og:title"', SHARE_TITLE);
+  out = replaceMeta(out, 'property="og:title"', title);
   out = replaceMeta(out, 'property="og:description"', description);
   out = replaceMeta(out, 'property="og:url"', options.url);
   out = replaceMeta(out, 'property="og:image"', SHARE_IMAGE);
-  out = replaceMeta(out, 'name="twitter:title"', SHARE_TITLE);
+  out = replaceMeta(out, 'name="twitter:title"', title);
   out = replaceMeta(out, 'name="twitter:description"', description);
   out = replaceMeta(out, 'name="twitter:image"', SHARE_IMAGE);
   return out;

--- a/tests/api/share-page.test.ts
+++ b/tests/api/share-page.test.ts
@@ -73,6 +73,37 @@ describe('share-page handler', () => {
     expect(res.body).toContain('content="oddeNova | Vibe Your Music, Live"');
   });
 
+  it('renders the shared session title and localized description from the blob payload', async () => {
+    vi.mocked(list).mockResolvedValue({
+      blobs: [{ url: 'https://blob.example/shares/share123.json' }],
+    } as never);
+    vi.stubGlobal('fetch', vi.fn(async (input: string | URL | Request) => {
+      if (String(input) === 'https://blob.example/shares/share123.json') {
+        return Response.json({
+          version: 1,
+          title: '雨夜里的松弛 Lo-fi',
+          code: 's("bd")',
+          messages: [],
+          sharedAt: 1_754_665_200_000,
+          locale: 'zh-CN',
+        });
+      }
+      return new Response(appShell, { status: 200 });
+    }));
+    const res = makeResponse();
+
+    await handler({
+      method: 'GET',
+      query: { id: 'share123' },
+      headers: { host: 'www.oddenova.com', 'x-forwarded-proto': 'https' },
+    } as never, res as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toContain('property="og:title" content="雨夜里的松弛 Lo-fi"');
+    expect(res.body).toContain('property="og:description" content="oddeNova 即兴 vibe 音乐，让灵感，自由发声"');
+    expect(res.body).toContain('<title>雨夜里的松弛 Lo-fi</title>');
+  });
+
   it('does not depend on client src modules at runtime', () => {
     const source = readFileSync(fileURLToPath(new URL('../../api/share-page.ts', import.meta.url)), 'utf8');
 


### PR DESCRIPTION
## Summary

- Render shared session titles in HTML, Open Graph, and Twitter metadata.
- Preserve the branded fallback title for payloads without a title.
- Prefix localized share descriptions with the oddeNova brand.
- Add coverage for title propagation and localized descriptions.

## Testing

- Added and updated unit and API tests for share-page metadata rendering.